### PR TITLE
test(unit): モックフィクスチャを共通化し、ユニットテストの一貫性を向上

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def mock_async_client(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("kabukit.core.client.AsyncClient").return_value
+
+
+@pytest.fixture
+def mock_post(mock_async_client: MagicMock, mocker: MockerFixture) -> AsyncMock:
+    mock_post = mocker.AsyncMock()
+    mock_async_client.post = mock_post
+    return mock_post
+
+
+@pytest.fixture
+def mock_get(mock_async_client: MagicMock, mocker: MockerFixture) -> AsyncMock:
+    mock_get = mocker.AsyncMock()
+    mock_async_client.get = mock_get
+    return mock_get

--- a/tests/unit/edinet/conftest.py
+++ b/tests/unit/edinet/conftest.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def mock_edinet_client_context(mocker: MockerFixture) -> AsyncMock:
+    """EdinetClientの非同期コンテキストマネージャをモックするフィクスチャ"""
+    mock_client_instance = mocker.AsyncMock()
+    mocker.patch(
+        "kabukit.edinet.concurrent.EdinetClient",
+        return_value=mocker.MagicMock(
+            __aenter__=mocker.AsyncMock(return_value=mock_client_instance),
+            __aexit__=mocker.AsyncMock(),
+        ),
+    )
+    return mock_client_instance

--- a/tests/unit/edinet/test_concurrent.py
+++ b/tests/unit/edinet/test_concurrent.py
@@ -141,24 +141,13 @@ async def test_get_entries_years(
 
 
 @pytest.mark.asyncio
-async def test_get_entries_single_date(
-    mocker: MockerFixture,
-) -> None:
+async def test_get_entries_single_date(mock_edinet_client_context: AsyncMock) -> None:
     from kabukit.edinet.concurrent import get_entries
-
-    mock_client_instance = mocker.AsyncMock()
-    mocker.patch(
-        "kabukit.edinet.concurrent.EdinetClient",
-        return_value=mocker.MagicMock(
-            __aenter__=mocker.AsyncMock(return_value=mock_client_instance),
-            __aexit__=mocker.AsyncMock(),
-        ),
-    )
 
     target_date = datetime.date(2025, 10, 10)
     await get_entries(target_date)
 
-    mock_client_instance.get_entries.assert_awaited_once_with(target_date)
+    mock_edinet_client_context.get_entries.assert_awaited_once_with(target_date)
 
 
 @pytest.mark.asyncio
@@ -227,18 +216,11 @@ async def test_get_documents_pdf(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_documents_single_doc_id(mocker: MockerFixture) -> None:
+async def test_get_documents_single_doc_id(
+    mock_edinet_client_context: AsyncMock,
+) -> None:
     from kabukit.edinet.concurrent import get_documents
-
-    mock_client_instance = mocker.AsyncMock()
-    mocker.patch(
-        "kabukit.edinet.concurrent.EdinetClient",
-        return_value=mocker.MagicMock(
-            __aenter__=mocker.AsyncMock(return_value=mock_client_instance),
-            __aexit__=mocker.AsyncMock(),
-        ),
-    )
 
     await get_documents("doc1", pdf=True)
 
-    mock_client_instance.get_document.assert_awaited_once_with("doc1", pdf=True)
+    mock_edinet_client_context.get_document.assert_awaited_once_with("doc1", pdf=True)

--- a/tests/unit/jquants/conftest.py
+++ b/tests/unit/jquants/conftest.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 from kabukit.jquants.client import JQuantsClient, _CalendarCacheManager
 
 if TYPE_CHECKING:
-    from unittest.mock import AsyncMock, MagicMock
+    from unittest.mock import AsyncMock
 
     from pytest_mock import MockerFixture
 
@@ -30,19 +30,14 @@ def reset_calendar_cache_manager(mocker: MockerFixture):
 
 
 @pytest.fixture
-def mock_async_client(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("kabukit.core.client.AsyncClient").return_value
-
-
-@pytest.fixture
-def mock_post(mock_async_client: MagicMock, mocker: MockerFixture) -> AsyncMock:
-    mock_post = mocker.AsyncMock()
-    mock_async_client.post = mock_post
-    return mock_post
-
-
-@pytest.fixture
-def mock_get(mock_async_client: MagicMock, mocker: MockerFixture) -> AsyncMock:
-    mock_get = mocker.AsyncMock()
-    mock_async_client.get = mock_get
-    return mock_get
+def mock_jquants_client_context(mocker: MockerFixture) -> AsyncMock:
+    """JQuantsClientの非同期コンテキストマネージャをモックするフィクスチャ"""
+    mock_client_instance = mocker.AsyncMock()
+    mocker.patch(
+        "kabukit.jquants.concurrent.JQuantsClient",
+        return_value=mocker.MagicMock(
+            __aenter__=mocker.AsyncMock(return_value=mock_client_instance),
+            __aexit__=mocker.AsyncMock(),
+        ),
+    )
+    return mock_client_instance

--- a/tests/unit/jquants/test_calendar.py
+++ b/tests/unit/jquants/test_calendar.py
@@ -12,27 +12,15 @@ from polars.testing import assert_frame_equal
 from kabukit.jquants.client import JQuantsClient
 
 if TYPE_CHECKING:
-    from unittest.mock import AsyncMock, MagicMock
+    from unittest.mock import AsyncMock
 
     from pytest_mock import MockerFixture
 
 pytestmark = pytest.mark.unit
 
 
-@pytest.fixture
-def async_client(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("kabukit.core.client.AsyncClient").return_value
-
-
-@pytest.fixture
-def get(async_client: MagicMock, mocker: MockerFixture) -> AsyncMock:
-    get = mocker.AsyncMock()
-    async_client.get = get
-    return get
-
-
 @pytest.mark.asyncio
-async def test_get_calendar(get: AsyncMock, mocker: MockerFixture) -> None:
+async def test_get_calendar(mock_get: AsyncMock, mocker: MockerFixture) -> None:
     """Test get_calendar method."""
     # 1. Mock the API response
     json_data = {
@@ -44,7 +32,7 @@ async def test_get_calendar(get: AsyncMock, mocker: MockerFixture) -> None:
         ],
     }
     response = Response(200, json=json_data)
-    get.return_value = response
+    mock_get.return_value = response
     response.raise_for_status = mocker.MagicMock()
 
     # 2. Call the method
@@ -80,16 +68,16 @@ async def test_get_calendar(get: AsyncMock, mocker: MockerFixture) -> None:
     )
 
     assert_frame_equal(result_df.sort("Date"), expected_df)
-    get.assert_awaited_once_with("/markets/trading_calendar", params={})
+    mock_get.assert_awaited_once_with("/markets/trading_calendar", params={})
 
 
 @pytest.mark.asyncio
-async def test_get_calendar_empty(get: AsyncMock, mocker: MockerFixture) -> None:
+async def test_get_calendar_empty(mock_get: AsyncMock, mocker: MockerFixture) -> None:
     """Test get_calendar method with an empty response."""
     # 1. Mock the API response
     json: dict[str, list[dict[str, str]]] = {"trading_calendar": []}
     response = Response(200, json=json)
-    get.return_value = response
+    mock_get.return_value = response
     response.raise_for_status = mocker.MagicMock()
 
     # 2. Call the method
@@ -98,4 +86,4 @@ async def test_get_calendar_empty(get: AsyncMock, mocker: MockerFixture) -> None
 
     # 3. Assert the result
     assert result_df.is_empty()
-    get.assert_awaited_once_with("/markets/trading_calendar", params={})
+    mock_get.assert_awaited_once_with("/markets/trading_calendar", params={})

--- a/tests/unit/jquants/test_concurrent.py
+++ b/tests/unit/jquants/test_concurrent.py
@@ -118,21 +118,12 @@ async def test_get_without_codes(
 
 
 @pytest.mark.asyncio
-async def test_get_info(mocker: MockerFixture) -> None:
+async def test_get_info(mock_jquants_client_context: AsyncMock) -> None:
     from kabukit.jquants.concurrent import get_info
-
-    mock_client_instance = mocker.AsyncMock()
-    mocker.patch(
-        "kabukit.jquants.concurrent.JQuantsClient",
-        return_value=mocker.MagicMock(
-            __aenter__=mocker.AsyncMock(return_value=mock_client_instance),
-            __aexit__=mocker.AsyncMock(),
-        ),
-    )
 
     await get_info("7203")
 
-    mock_client_instance.get_info.assert_awaited_once_with("7203")
+    mock_jquants_client_context.get_info.assert_awaited_once_with("7203")
 
 
 @pytest.mark.asyncio
@@ -200,21 +191,14 @@ async def test_get_statements(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_statements_with_single_code(mocker: MockerFixture) -> None:
+async def test_get_statements_with_single_code(
+    mock_jquants_client_context: AsyncMock,
+) -> None:
     from kabukit.jquants.concurrent import get_statements
-
-    mock_client_instance = mocker.AsyncMock()
-    mocker.patch(
-        "kabukit.jquants.concurrent.JQuantsClient",
-        return_value=mocker.MagicMock(
-            __aenter__=mocker.AsyncMock(return_value=mock_client_instance),
-            __aexit__=mocker.AsyncMock(),
-        ),
-    )
 
     await get_statements("7203")
 
-    mock_client_instance.get_statements.assert_awaited_once_with("7203")
+    mock_jquants_client_context.get_statements.assert_awaited_once_with("7203")
 
 
 @pytest.mark.asyncio
@@ -245,18 +229,11 @@ async def test_get_prices(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_prices_with_single_code(mocker: MockerFixture) -> None:
+async def test_get_prices_with_single_code(
+    mock_jquants_client_context: AsyncMock,
+) -> None:
     from kabukit.jquants.concurrent import get_prices
-
-    mock_client_instance = mocker.AsyncMock()
-    mocker.patch(
-        "kabukit.jquants.concurrent.JQuantsClient",
-        return_value=mocker.MagicMock(
-            __aenter__=mocker.AsyncMock(return_value=mock_client_instance),
-            __aexit__=mocker.AsyncMock(),
-        ),
-    )
 
     await get_prices("7203")
 
-    mock_client_instance.get_prices.assert_awaited_once_with("7203")
+    mock_jquants_client_context.get_prices.assert_awaited_once_with("7203")


### PR DESCRIPTION
httpx.AsyncClient をモックするフィクスチャ (`mock_get`, `mock_post` など) を `tests/unit/conftest.py` に集約し、`jquants` と `edinet` のテスト間で共有するようにした。

これにより、各テストファイルに散在していた重複したフィクスチャ定義を削除。

`async with Client()` 構文をモックするための専用フィクスチャ (`mock_*_client_context`) を作成し、コンテキストマネージャのテストパターンを共通化。

これにより、テストコードの記述が簡潔になり、メンテナンス性が向上した。