### PR TITLE
test(system): J-Quants認証のシステムテストを強化

### DIFF
--- a/tests/system/jquants/test_auth.py
+++ b/tests/system/jquants/test_auth.py
@@ -1,0 +1,85 @@
+import os
+from pathlib import Path
+
+import pytest
+from httpx import HTTPStatusError
+from polars import DataFrame
+from pytest_mock import MockerFixture
+
+from kabukit.jquants.client import JQuantsClient
+
+pytestmark = pytest.mark.system
+
+is_auth_set = bool(os.getenv("JQUANTS_MAILADDRESS") and os.getenv("JQUANTS_PASSWORD"))
+reason = "JQUANTS_MAILADDRESS and JQUANTS_PASSWORD must be set"
+
+
+@pytest.mark.skipif(not is_auth_set, reason=reason)
+@pytest.mark.asyncio
+async def test_auth_from_config(client: JQuantsClient) -> None:
+    id_token = await client.auth()
+    assert id_token is not None
+
+
+@pytest.mark.skipif(not is_auth_set, reason=reason)
+@pytest.mark.asyncio
+async def test_auth_from_args(client: JQuantsClient) -> None:
+    mailaddress = os.getenv("JQUANTS_MAILADDRESS")
+    password = os.getenv("JQUANTS_PASSWORD")
+    id_token = await client.auth(mailaddress, password)
+    assert id_token is not None
+
+
+@pytest.mark.asyncio
+async def test_auth_invalid(client: JQuantsClient) -> None:
+    with pytest.raises(HTTPStatusError):
+        await client.auth("invalid_email", "invalid_password")
+
+
+@pytest.mark.skipif(not is_auth_set, reason=reason)
+@pytest.mark.asyncio
+async def test_auth_and_reread_from_config(
+    client: JQuantsClient,
+    mocker: MockerFixture,
+    tmp_path: Path,
+) -> None:
+    from kabukit.jquants.client import AuthKey
+    from kabukit.utils.config import get_config_path, save_config_key
+
+    mocker.patch(
+        "kabukit.utils.config.get_config_path",
+        return_value=tmp_path / "config.toml",
+    )
+
+    id_token = await client.auth()
+    assert id_token is not None
+
+    save_config_key(AuthKey.ID_TOKEN, id_token)
+
+    client = JQuantsClient()
+    assert id_token in client.client.headers["Authorization"]
+
+    path = get_config_path()
+    assert path.parent == tmp_path
+    assert id_token in path.read_text()
+
+
+@pytest.mark.skipif(not is_auth_set, reason=reason)
+@pytest.mark.asyncio
+async def test_auth_and_get_data(client: JQuantsClient) -> None:
+    id_token = await client.auth()
+    assert id_token is not None
+
+    df = await client.get_info(code="80310")
+    assert isinstance(df, DataFrame)
+    assert not df.is_empty()
+
+
+@pytest.mark.skipif(
+    is_auth_set,
+    reason="JQUANTS_MAILADDRESS and JQUANTS_PASSWORD are set",
+)
+@pytest.mark.asyncio
+async def test_auth_error(client: JQuantsClient) -> None:
+    with pytest.raises(ValueError, match="メールアドレス"):
+        await client.auth()


### PR DESCRIPTION
認証成功後に、実際にAPIアクセス（`get_info`）が成功することを確認するテストケース (`test_auth_and_get_data`) を追加。

認証で取得したトークンを設定ファイルに保存し、新しいクライアントインスタンスがその設定を正しく読み込めることを確認するテストケース (`test_auth_and_reread_from_config`) を追加。

後者のテストでは、`tmp_path` を利用してテストごとに設定ファイルを隔離し、副作用なしに安全に実行できるようにした。

`skipif` の理由メッセージを共通変数にまとめた。