### PR TITLE
fix(ci): Codecovレポートの重複アップロードを修正

### DIFF
--- a/.github/workflows/code-quality-tests.yaml
+++ b/.github/workflows/code-quality-tests.yaml
@@ -45,13 +45,13 @@ jobs:
       - name: Run tests
         run: uv run pytest -v -m unit --junitxml=junit.xml
       - name: Upload Codecov Results
-        if: success()
+        if: success() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() }} && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
code-quality-tests.yaml ワークフローにおいて、`unit-tests-linting` ジョブがマトリックスで実行されるすべての環境でCodecovにカバレッジレポートとテスト結果をアップロードしていた問題を修正。

Codecovへのアップロードは、`ubuntu-latest` かつ `Python 3.14` の環境でのみ実行されるように `if` 条件を追加した。

これにより、Codecov上でのレポートの重複を防ぎ、集計の正確性を向上させる。