### PR TITLE
fix(ci): CIのEDINETシステムテスト失敗を修正 & デバッグコード削除

### DIFF
--- a/.github/workflows/code-quality-tests.yaml
+++ b/.github/workflows/code-quality-tests.yaml
@@ -76,10 +76,6 @@ jobs:
           JQUANTS_MAILADDRESS: ${{ secrets.JQUANTS_MAILADDRESS }}
           JQUANTS_PASSWORD: ${{ secrets.JQUANTS_PASSWORD }}
         run: uv run kabu auth jquants
-      - name: Authenticate (EDINET)
-        env:
-          EDINET_API_KEY: ${{ secrets.EDINET_API_KEY }}
-        run: uv run kabu auth edinet
       - name: Cache and get data
         id: cache-data
         uses: actions/cache@v4
@@ -90,6 +86,10 @@ jobs:
         if: steps.cache-data.outputs.cache-hit != 'true'
         run: uv run kabu get statements
       - name: Run all tests
+        env:
+          JQUANTS_MAILADDRESS: ${{ secrets.JQUANTS_MAILADDRESS }}
+          JQUANTS_PASSWORD: ${{ secrets.JQUANTS_PASSWORD }}
+          EDINET_API_KEY: ${{ secrets.EDINET_API_KEY }}
         run: uv run pytest -v --junitxml=junit.xml
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/tests/system/edinet/conftest.py
+++ b/tests/system/edinet/conftest.py
@@ -1,20 +1,9 @@
 import pytest_asyncio
 
-from kabukit.edinet.client import AuthKey as EdinetAuthKey
-from kabukit.utils.config import get_config_value
-
 
 @pytest_asyncio.fixture
 async def client():
     from kabukit.edinet.client import EdinetClient
 
-    # デバッグ用: APIキーが正しく取得されているか確認
-    key = get_config_value(EdinetAuthKey.API_KEY)
-    assert key
-    print(f"\n[DEBUG] API Key from config/env: {key[:10]}")  # noqa: T201
-
     async with EdinetClient() as client:
-        key = client.client.params.get("Subscription-Key")
-        assert key
-        print(f"[DEBUG] EdinetClient Subscription-Key: {key[:10]}")  # noqa: T201
         yield client


### PR DESCRIPTION
full-integration-tests ジョブにおいて、EDINET関連のシステムテストが失敗していた問題を修正。

`Authenticate (EDINET)` ステップを削除し、`Run all tests` ステップの `env` に `EDINET_API_KEY` を直接追加することで、テスト実行時にAPIキーが利用可能になるようにした。

`tests/system/edinet/conftest.py` に追加していたデバッグコードを削除し、元の状態に戻した。

これにより、EDINET関連のシステムテストがCI環境で正しく実行されることを期待する。