### PR TITLE
fix(test): CIのシステムテスト失敗を修正し、テストを安定化

### DIFF
--- a/tests/system/cli/test_auth.py
+++ b/tests/system/cli/test_auth.py
@@ -49,7 +49,7 @@ def test_auth_jquants_success(
 @pytest.mark.skipif(not is_auth_set, reason=reason)
 def test_auth_jquants_success_and_get_data(authenticated_cli_session: None) -> None:  # noqa: ARG001  # pyright: ignore[reportUnusedParameter]
     """auth jquants コマンドで認証後、別のCLIコマンドが成功することを確認する"""
-    result_get_info = runner.invoke(app, ["get", "info", "--max-items", "1"])
+    result_get_info = runner.invoke(app, ["get", "info", "7203"])
     assert result_get_info.exit_code == 0
     assert "Code" in result_get_info.stdout  # データが取得されたことを確認
 

--- a/tests/system/jquants/test_auth.py
+++ b/tests/system/jquants/test_auth.py
@@ -44,7 +44,7 @@ async def test_auth_and_reread_from_config(
     tmp_path: Path,
 ) -> None:
     from kabukit.jquants.client import AuthKey
-    from kabukit.utils.config import get_config_path, save_config_key
+    from kabukit.utils.config import save_config_key
 
     mocker.patch(
         "kabukit.utils.config.get_config_path",
@@ -58,10 +58,7 @@ async def test_auth_and_reread_from_config(
 
     client = JQuantsClient()
     assert id_token in client.client.headers["Authorization"]
-
-    path = get_config_path()
-    assert path.parent == tmp_path
-    assert id_token in path.read_text()
+    assert id_token in (tmp_path / "config.toml").read_text()
 
 
 @pytest.mark.skipif(not is_auth_set, reason=reason)


### PR DESCRIPTION
tests/system/cli/test_auth.py:
  - test_auth_jquants_success_and_get_data テストにおいて、kabu get info コマンドで特定の銘柄コード (7203) を指定するように変更し、テストの再現性と安定性を向上させた。
tests/system/jquants/test_auth.py:
  - test_auth_and_reread_from_config テストにおいて、get_config_path の呼び出しを削除し、tmp_path / "config.toml" を直接参照するように変更することで、テストコードを簡潔にした。
  - これにより、CIで発生していたシステムテストの失敗を修正し、テストの安定化を図る。