### PR TITLE
fix(cli): `auth edinet`のキー更新動作を修正

### DIFF
--- a/src/kabukit/cli/auth.py
+++ b/src/kabukit/cli/auth.py
@@ -103,16 +103,12 @@ def edinet_alias(api_key: ApiKey = None) -> None:
 
 def auth_edinet(api_key: str | None) -> None:
     """EDINET APIのAPIキーを設定ファイルに保存します。"""
-
-    if not api_key and get_config_value(EdinetAuthKey.API_KEY):
-        typer.echo("既存のAPIキーを使います。")
-        raise typer.Exit(0)
-
     if api_key is None:
         api_key = typer.prompt("EDINETで取得したAPIキー")
-        if not api_key or api_key.strip() == "":
-            typer.echo("APIキーが入力されていません。")
-            raise Exit(1)
+
+    if not api_key or api_key.strip() == "":
+        typer.echo("APIキーが入力されていません。")
+        raise Exit(1)
 
     save_config_key(EdinetAuthKey.API_KEY, api_key)
     typer.echo("EDINETのAPIキーを保存しました。")
@@ -120,7 +116,7 @@ def auth_edinet(api_key: str | None) -> None:
 
 @app.command()
 def show() -> None:
-    """設定ファイルに保存したトークン・APIキーを表示します。"""
+    """設定ファイルに保存したJ-Quants IDトークンおよびEDINET APIキーを表示します。"""
     path = get_config_path()
     typer.echo(f"設定ファイル: {path}")
 

--- a/tests/unit/cli/test_auth.py
+++ b/tests/unit/cli/test_auth.py
@@ -209,20 +209,27 @@ def test_edinet_success_cli_arg(
 
 
 @pytest.mark.parametrize("command", ["edinet", "e"])
-def test_edinet_success_config_fallback(
+def test_edinet_always_prompts_when_no_args(
     mock_get_config_value: MagicMock,
     mock_save_config_key: MagicMock,
     mock_typer_prompt: MagicMock,
     command: str,
 ) -> None:
-    mock_get_config_value.return_value = "config_api_key"
+    """引数なしの場合、既存のキーがあっても常にプロンプトを表示することをテストする"""
+    # 既存のキーが設定されている状況をシミュレート
+    mock_get_config_value.return_value = "existing_api_key"
+    # ユーザーがプロンプトに新しいキーを入力する状況をシミュレート
+    mock_typer_prompt.return_value = "new_api_key"
 
     result = runner.invoke(app, ["auth", command])
 
     assert result.exit_code == 0
-    assert "既存のAPIキーを使います。" in result.stdout
-    mock_save_config_key.assert_not_called()
-    mock_typer_prompt.assert_not_called()
+    # プロンプトが表示されたことを確認
+    mock_typer_prompt.assert_called_once_with("EDINETで取得したAPIキー")
+    # 新しいキーで保存関数が呼び出されたことを確認
+    mock_save_config_key.assert_called_once_with(EdinetAuthKey.API_KEY, "new_api_key")
+    # 出力メッセージが正しいことを確認
+    assert "EDINETのAPIキーを保存しました。" in result.stdout
 
 
 @pytest.mark.parametrize("command", ["edinet", "e"])


### PR DESCRIPTION
`kabu auth edinet`を引数なしで実行した際に、既存のキーがあっても常に新しいキーの入力を促すように修正しました。 これにより、ユーザーがインタラクティブにAPIキーを更新できない問題が解決されます。

また、引数で空文字が渡された場合にエラーとするように、バリデーションを改善しました。

Refs: #88