### PR TITLE
fix: scope table styles to `.dataframe` class only

### DIFF
--- a/docs/css/kabukit.css
+++ b/docs/css/kabukit.css
@@ -1,24 +1,19 @@
-th,
-td {
+.dataframe th,
+.dataframe td {
   font-size: 80%;
   padding-left: 4px;
   padding-right: 4px;
+  text-align: center;
 }
 
-thead th {
+.dataframe thead th {
   font-weight: bold;
-  text-align: center;
+}
+
+.dataframe thead td {
+  color: gray;
 }
 
 .dataframe thead tr:first-child {
   border-bottom: 1px solid rgba(128, 128, 128, 0.2);
-}
-
-thead td {
-  color: gray;
-  text-align: center;
-}
-
-tbody td {
-  text-align: center;
 }


### PR DESCRIPTION
- Prevent API reference source code from being center-aligned
- Limit table styling to Polars `dataframe` output only
- Use `.dataframe` class selector instead of global `th`/`td`

Fixes #97