### PR TITLE
feat: `cache.write` 関数を拡張し、ファイル名を指定可能にする

### DIFF
--- a/src/kabukit/core/base.py
+++ b/src/kabukit/core/base.py
@@ -22,21 +22,21 @@ class Base:
         self,
         data: DataFrame | None = None,
         *,
-        path: str | Path | None = None,
+        name: str | None = None,
     ) -> None:
         if data is not None:
             self.data = data
             return
 
-        self.data = cache.read(self.__class__.__name__.lower(), path)
+        self.data = cache.read(self.__class__.__name__.lower(), name)
 
     @classmethod
     def data_dir(cls) -> Path:
         clsname = cls.__name__.lower()
         return get_cache_dir() / clsname
 
-    def write(self) -> Path:
-        return cache.write(self.__class__.__name__.lower(), self.data)
+    def write(self, name: str | None = None) -> Path:
+        return cache.write(self.__class__.__name__.lower(), self.data, name)
 
     def filter(
         self,

--- a/src/kabukit/core/cache.py
+++ b/src/kabukit/core/cache.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-from pathlib import Path
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
@@ -11,50 +10,43 @@ from kabukit.utils.config import get_cache_dir
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
     from polars import DataFrame
 
 
-def glob(name: str | None = None) -> Iterator[Path]:
+def glob(group: str | None = None) -> Iterator[Path]:
     """Glob parquet files in the cache directory.
 
     Args:
-        name (str | None, optional): The name of the cache
-            subdirectory (e.g., "info", "statements").
-            If None, it globs all `*.parquet` files recursively.
+        group: The name of the cache subdirectory (e.g., "info", "statements").
+              If None, it globs all `*.parquet` files recursively.
 
-    Yields:
-        Path: An iterator of Path objects for the matched parquet files.
+    Returns:
+        An iterator of Path objects for the matched parquet files.
     """
-    if name is None:
+    if group is None:
         yield from get_cache_dir().glob("**/*.parquet")
     else:
-        yield from get_cache_dir().joinpath(name).glob("*.parquet")
+        data_dir = get_cache_dir() / group
+        yield from data_dir.glob("*.parquet")
 
 
-def _get_latest_filepath(name: str) -> Path:
-    filenames = sorted(glob(name))
+def _get_latest_filepath(group: str) -> Path:
+    filenames = sorted(glob(group))
 
     if not filenames:
-        msg = f"No data found for {name} in the cache directory"
+        msg = f"No data found for {group}"
         raise FileNotFoundError(msg)
 
     return filenames[-1]
 
 
-def _get_cache_filepath(name: str, path: str | Path | None = None) -> Path:
-    if path is None:
-        return _get_latest_filepath(name)
+def _get_cache_filepath(group: str, name: str | None = None) -> Path:
+    if name is None:
+        return _get_latest_filepath(group)
 
-    data_dir = get_cache_dir() / name
-
-    if isinstance(path, str):
-        path = Path(path)
-
-    if path.exists():
-        return path
-
-    filename = data_dir / path
+    filename = get_cache_dir() / group / f"{name}.parquet"
 
     if not filename.exists():
         msg = f"File not found: {filename}"
@@ -63,12 +55,12 @@ def _get_cache_filepath(name: str, path: str | Path | None = None) -> Path:
     return filename
 
 
-def read(name: str, path: str | Path | None = None) -> DataFrame:
-    """Read a polars.DataFrame directly from the cache.
+def read(group: str, name: str | None = None) -> DataFrame:
+    """Reads a polars.DataFrame directly from the cache.
 
     Args:
-        name: The name of the cache subdirectory (e.g., "info", "statements").
-        path: Optional. A specific path to a Parquet file within the cache.
+        group: The name of the cache subdirectory (e.g., "info", "statements").
+        name: Optional. A specific filename (without extension) within the cache group.
               If None, the latest file in the subdirectory is read.
 
     Returns:
@@ -77,23 +69,29 @@ def read(name: str, path: str | Path | None = None) -> DataFrame:
     Raises:
         FileNotFoundError: If no data is found in the cache.
     """
-    filepath = _get_cache_filepath(name, path)
+    filepath = _get_cache_filepath(group, name)
     return pl.read_parquet(filepath)
 
 
-def write(name: str, df: DataFrame) -> Path:
-    """Write a polars.DataFrame directly to the cache.
+def write(group: str, df: DataFrame, name: str | None = None) -> Path:
+    """Writes a polars.DataFrame directly to the cache.
 
     Args:
-        name: The name of the cache subdirectory (e.g., "info", "statements").
+        group: The name of the cache subdirectory (e.g., "info", "statements").
         df: The polars.DataFrame to write.
+        name: Optional. The filename (without extension) for the parquet file.
+              If None, a timestamp is used as the filename.
 
     Returns:
         Path: The path to the written Parquet file.
     """
-    data_dir = get_cache_dir() / name
+    data_dir = get_cache_dir() / group
     data_dir.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y%m%d")
-    filename = data_dir / f"{timestamp}.parquet"
+    if name is None:
+        timestamp = datetime.datetime.now(ZoneInfo("Asia/Tokyo")).strftime("%Y%m%d")
+        filename = data_dir / f"{timestamp}.parquet"
+    else:
+        filename = data_dir / f"{name}.parquet"
+
     df.write_parquet(filename)
     return filename

--- a/tests/unit/core/test_base.py
+++ b/tests/unit/core/test_base.py
@@ -34,14 +34,24 @@ def test_data_dir(mocker: MockerFixture, cls: type[Base], name: str) -> None:
     mock_user_cache_dir.assert_called_once_with("kabukit", appauthor=False)
 
 
-def test_write(mocker: MockerFixture, data: DataFrame) -> None:
+def test_write_no_name(mocker: MockerFixture, data: DataFrame) -> None:
     mock_cache_write = mocker.patch(
         "kabukit.core.cache.write",
         return_value=Path("mocked_path.parquet"),
     )
     path = Base(data).write()
     assert path == Path("mocked_path.parquet")
-    mock_cache_write.assert_called_once_with("base", data)
+    mock_cache_write.assert_called_once_with("base", data, None)
+
+
+def test_write_with_name(mocker: MockerFixture, data: DataFrame) -> None:
+    mock_cache_write = mocker.patch(
+        "kabukit.core.cache.write",
+        return_value=Path("mocked_path.parquet"),
+    )
+    path = Base(data).write(name="my_file")
+    assert path == Path("mocked_path.parquet")
+    mock_cache_write.assert_called_once_with("base", data, "my_file")
 
 
 def test_init_from_cache(mocker: MockerFixture, data: DataFrame) -> None:
@@ -59,10 +69,10 @@ def test_init_from_cache(mocker: MockerFixture, data: DataFrame) -> None:
     assert_frame_equal(base.data, df2)
     mock_cache_read_base.assert_any_call("base", None)  # Check for latest
 
-    base = Base(path="20231026.parquet")
+    base = Base(name="20231026")
     assert isinstance(base, Base)
     assert_frame_equal(base.data, df1)
-    mock_cache_read_base.assert_any_call("base", "20231026.parquet")
+    mock_cache_read_base.assert_any_call("base", "20231026")
 
     # Mock cache.read for Derived class
     mock_cache_read_derived = mocker.patch("kabukit.core.cache.read", return_value=df2)


### PR DESCRIPTION
## 概要

現在の `kabukit.core.cache.write` 関数は、キャッシュファイル名が日付 (`YYYYMMDD.parquet`) に固定されています。
`read` 関数が `path` オプションで読み込むファイルを指定できるように、`write` 関数も書き込むファイル名を指定できると、より柔軟で便利になります。

また、APIの明確性を向上させるため、関連する関数のパラメータ名を以下のように変更することを提案します。

- `name` -> `group` (キャッシュのサブディレクトリを表す)
- `path` -> `name` (`group` 内のファイル名を表す)

これまで、`path`は `Path`を受け入れ可能でしたが、`str`に限定し、かつ拡張子は不要とします。また、`Path`ではなくなったので、絶対パスが与えられることを想定しません。関連するテストの修正が必要です。

## 実装案

1.  **パラメータ名の変更 (Refactoring):**
    -   `src/kabukit/core/cache.py` 内の以下の関数のシグネチャを変更します。
        -   `glob(name=None)` -> `glob(group=None)`
        -   `_get_latest_filepath(name)` -> `_get_latest_filepath(group)`
        -   `_get_cache_filepath(name, path=None)` -> `_get_cache_filepath(group, name=None)`
        -   `read(name, path=None)` -> `read(group, name=None)`
        -   `write(name, df)` -> `write(group, df, name=None)`
    -   上記変更に伴い、関数内の実装と、これらの関数を呼び出しているすべての箇所（テストコードやCLIコードを含む）を修正します。

2.  **`write` 関数の機能拡張:**
    -   新しい `write(group, df, name=None)` 関数を実装します。
    -   `name` が指定されていない場合（`None` の場合）は、これまで通りタイムスタンプ (`YYYYMMDD.parquet`) をファイル名として使用します。
    -   `name` が指定されている場合は、その値をファイル名として使用します (例: `group/name.parquet`)。

3.  **テストの更新:**
    -   `tests/unit/core/test_cache.py` を更新し、新しいパラメータ名と `write` 関数の新しい機能をテストします。