### PR TITLE
chore: simplify matrix strategy in CI workflow

### DIFF
--- a/.github/workflows/code-quality-tests.yaml
+++ b/.github/workflows/code-quality-tests.yaml
@@ -21,14 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.12", "3.13"]
-        include:
-          - os: ubuntu-latest
-            python-version: "3.14"
-          - os: windows-latest
-            python-version: "3.14"
-          - os: macos-latest
-            python-version: "3.14"
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Simplify the GitHub Actions workflow matrix configuration by removing the redundant `include` section.

## Changes

- Replace `include` section with a direct matrix definition
- Python 3.14 is now part of the main matrix instead of being added separately
- Result: Same test coverage (9 jobs: 3 OS × 3 Python versions) with cleaner configuration

## Benefits

- More maintainable and easier to read
- Follows GitHub Actions best practices
- Reduces configuration complexity