### PR TITLE
refactor: Standardize polars import style

### DIFF
--- a/src/kabukit/analysis/visualization/market.py
+++ b/src/kabukit/analysis/visualization/market.py
@@ -5,12 +5,12 @@ from typing import TYPE_CHECKING
 import altair as alt
 
 if TYPE_CHECKING:
-    from polars import DataFrame
+    import polars as pl
 
 # pyright: reportUnknownMemberType=false
 
 
-def plot_topix_timeseries(df: DataFrame) -> alt.Chart:
+def plot_topix_timeseries(df: pl.DataFrame) -> alt.Chart:
     """TOPIXの時系列データを折れ線グラフでプロットする。"""
     return (
         alt.Chart(df, title="TOPIX 時系列チャート")

--- a/src/kabukit/domain/base.py
+++ b/src/kabukit/domain/base.py
@@ -11,16 +11,16 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, Self
 
-    from polars import DataFrame
+    import polars as pl
     from polars._typing import IntoExprColumn
 
 
 class Base:
-    data: DataFrame
+    data: pl.DataFrame
 
     def __init__(
         self,
-        data: DataFrame | None = None,
+        data: pl.DataFrame | None = None,
         *,
         name: str | None = None,
     ) -> None:

--- a/src/kabukit/domain/cache.py
+++ b/src/kabukit/domain/cache.py
@@ -13,8 +13,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
-    from polars import DataFrame
-
 
 def glob(source: str | None = None, group: str | None = None) -> Iterator[Path]:
     """Glob parquet files in the cache directory.
@@ -64,7 +62,7 @@ def _get_cache_filepath(source: str, group: str, name: str | None = None) -> Pat
     return filename
 
 
-def read(source: str, group: str, name: str | None = None) -> DataFrame:
+def read(source: str, group: str, name: str | None = None) -> pl.DataFrame:
     """Read a polars.DataFrame directly from the cache.
 
     Args:
@@ -83,7 +81,7 @@ def read(source: str, group: str, name: str | None = None) -> DataFrame:
     return pl.read_parquet(filepath)
 
 
-def write(source: str, group: str, df: DataFrame, name: str | None = None) -> Path:
+def write(source: str, group: str, df: pl.DataFrame, name: str | None = None) -> Path:
     """Write a polars.DataFrame directly to the cache.
 
     Args:

--- a/src/kabukit/domain/jquants/prices.py
+++ b/src/kabukit/domain/jquants/prices.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:
     from datetime import timedelta
     from typing import Self
 
-    from polars import DataFrame, Expr
-
     from .statements import Statements
 
 
@@ -27,7 +25,7 @@ class Prices(Base):
         data (pl.DataFrame): 株価の時系列データ。
     """
 
-    def truncate(self, every: str | timedelta | Expr) -> Self:
+    def truncate(self, every: str | timedelta | pl.Expr) -> Self:
         """時系列データを指定された頻度で集計し、切り詰める。
 
         日次などの時系列データを指定された頻度（例: 月次、週次）で集計し、
@@ -339,7 +337,7 @@ class Prices(Base):
             .with_dividend_yield()
         )
 
-    def period_stats(self) -> DataFrame:
+    def period_stats(self) -> pl.DataFrame:
         """各期ごとの各種利回りおよび調整済み終値の統計量を計算する。
 
         `Code`と`ReportDate`で定義される各期（決算期間）ごとに、

--- a/src/kabukit/domain/jquants/statements.py
+++ b/src/kabukit/domain/jquants/statements.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import polars as pl
 
 from kabukit.domain.base import Base
-
-if TYPE_CHECKING:
-    from polars import DataFrame
 
 
 class Statements(Base):
@@ -22,7 +17,7 @@ class Statements(Base):
         data (pl.DataFrame): 財務諸表の時系列データ。
     """
 
-    def shares(self) -> DataFrame:
+    def shares(self) -> pl.DataFrame:
         """発行済株式数と自己株式数を時系列データとして抽出する。
 
         財務情報の中から、株式数に関連する情報（発行済株式数、自己株式数）を
@@ -41,7 +36,7 @@ class Statements(Base):
             "TreasuryShares",
         )
 
-    def equity(self) -> DataFrame:
+    def equity(self) -> pl.DataFrame:
         """純資産を時系列データとして抽出する。
 
         財務情報の中から、純資産の情報を時系列データとして抽出する。
@@ -53,7 +48,7 @@ class Statements(Base):
             pl.col("Equity").is_not_null(),
         ).select("Date", "Code", "Equity")
 
-    def forecast_profit(self) -> DataFrame:
+    def forecast_profit(self) -> pl.DataFrame:
         """予想純利益を時系列データとして抽出する。
 
         決算種別(`TypeOfDocument`)に応じて、通期決算（FY）の場合は
@@ -74,7 +69,7 @@ class Statements(Base):
             .select("Date", "Code", "ForecastProfit")
         )
 
-    def forecast_dividend(self) -> DataFrame:
+    def forecast_dividend(self) -> pl.DataFrame:
         """予想年間配当総額を時系列データとして抽出する。
 
         J-Quants APIでは配当総額の予想値が直接提供されないため、

--- a/src/kabukit/sources/edinet/concurrent.py
+++ b/src/kabukit/sources/edinet/concurrent.py
@@ -11,7 +11,7 @@ from .client import EdinetClient
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from polars import DataFrame
+    import polars as pl
 
     from kabukit.utils.concurrent import Callback, Progress
 
@@ -24,7 +24,7 @@ async def get(
     max_concurrency: int | None = None,
     progress: Progress | None = None,
     callback: Callback | None = None,
-) -> DataFrame:
+) -> pl.DataFrame:
     """引数に対応する各種データを取得し、単一のDataFrameにまとめて返す。
 
     Args:
@@ -65,7 +65,7 @@ async def get_entries(
     max_concurrency: int | None = None,
     progress: Progress | None = None,
     callback: Callback | None = None,
-) -> DataFrame:
+) -> pl.DataFrame:
     """過去 days 日または years 年の文書一覧を取得し、単一の DataFrame にまとめて返す。
 
     Args:
@@ -119,7 +119,7 @@ async def get_documents(
     callback: Callback | None = None,
     *,
     pdf: bool = False,
-) -> DataFrame:
+) -> pl.DataFrame:
     """文書をCSV形式あるいはPDF形式で取得し、単一のDataFrameにまとめて返す。
 
     Args:

--- a/src/kabukit/sources/edinet/doc.py
+++ b/src/kabukit/sources/edinet/doc.py
@@ -4,10 +4,9 @@ import datetime
 from zoneinfo import ZoneInfo
 
 import polars as pl
-from polars import DataFrame
 
 
-def clean_entries(df: DataFrame, date: str | datetime.date) -> DataFrame:
+def clean_entries(df: pl.DataFrame, date: str | datetime.date) -> pl.DataFrame:
     if isinstance(date, str):
         date = (
             datetime.datetime.strptime(date, "%Y-%m-%d")
@@ -37,11 +36,11 @@ def clean_entries(df: DataFrame, date: str | datetime.date) -> DataFrame:
     )
 
 
-def clean_pdf(content: bytes, doc_id: str) -> DataFrame:
-    return DataFrame({"docID": [doc_id], "pdf": [content]})
+def clean_pdf(content: bytes, doc_id: str) -> pl.DataFrame:
+    return pl.DataFrame({"docID": [doc_id], "pdf": [content]})
 
 
-def read_csv(data: bytes) -> DataFrame:
+def read_csv(data: bytes) -> pl.DataFrame:
     return pl.read_csv(
         data,
         separator="\t",
@@ -50,7 +49,7 @@ def read_csv(data: bytes) -> DataFrame:
     )
 
 
-def clean_csv(df: DataFrame, doc_id: str) -> DataFrame:
+def clean_csv(df: pl.DataFrame, doc_id: str) -> pl.DataFrame:
     return df.select(
         pl.lit(doc_id).alias("docID"),
         pl.all(),

--- a/src/kabukit/sources/jquants/calendar.py
+++ b/src/kabukit/sources/jquants/calendar.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import polars as pl
-from polars import DataFrame
 
 
-def clean(df: DataFrame) -> DataFrame:
+def clean(df: pl.DataFrame) -> pl.DataFrame:
     return df.with_columns(
         pl.col("Date").str.to_date("%Y-%m-%d"),
         pl.col("HolidayDivision").cast(pl.Categorical),

--- a/src/kabukit/sources/jquants/client.py
+++ b/src/kabukit/sources/jquants/client.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, final
 from zoneinfo import ZoneInfo
 
 import polars as pl
-from polars import DataFrame
 
 from kabukit.sources.base import Client
 from kabukit.utils.config import get_config_value
@@ -157,7 +156,7 @@ class JQuantsClient(Client):
         url: str,
         params: dict[str, Any] | None,
         name: str,
-    ) -> AsyncIterator[DataFrame]:
+    ) -> AsyncIterator[pl.DataFrame]:
         """ページ分割されたAPIレスポンスを非同期に反復処理する。
 
         J-Quants APIのページネーション仕様（`pagination_key`）に対応し、
@@ -178,7 +177,7 @@ class JQuantsClient(Client):
 
         while True:
             data = await self.get(url, params)
-            yield DataFrame(data[name])
+            yield pl.DataFrame(data[name])
             if "pagination_key" in data:
                 params["pagination_key"] = data["pagination_key"]
             else:
@@ -190,7 +189,7 @@ class JQuantsClient(Client):
         date: str | datetime.date | None = None,
         *,
         clean: bool = True,
-    ) -> DataFrame:
+    ) -> pl.DataFrame:
         """上場銘柄一覧を取得する (listed/info)。
 
         Args:
@@ -207,7 +206,7 @@ class JQuantsClient(Client):
         params = get_params(code=code, date=date)
         url = "/listed/info"
         data = await self.get(url, params)
-        df = DataFrame(data["info"])
+        df = pl.DataFrame(data["info"])
         return info.clean(df) if clean else df
 
     async def get_statements(
@@ -217,7 +216,7 @@ class JQuantsClient(Client):
         *,
         clean: bool = True,
         with_date: bool = True,
-    ) -> DataFrame:
+    ) -> pl.DataFrame:
         """財務情報を取得する (fins/statements)。
 
         Args:
@@ -263,7 +262,7 @@ class JQuantsClient(Client):
         to: str | datetime.date | None = None,
         *,
         clean: bool = True,
-    ) -> DataFrame:
+    ) -> pl.DataFrame:
         """日々の株価四本値を取得する (prices/daily_quotes)。
 
         Args:
@@ -305,7 +304,7 @@ class JQuantsClient(Client):
         num_days: int = 30,
         *,
         clean: bool = True,
-    ) -> DataFrame:
+    ) -> pl.DataFrame:
         """直近利用可能な日付の株価を取得する。
 
         `get_prices` のためのフォールバック処理。今日から過去`num_days`の範囲で
@@ -328,9 +327,9 @@ class JQuantsClient(Client):
             if not df.is_empty():
                 return df
 
-        return DataFrame()
+        return pl.DataFrame()
 
-    async def get_announcement(self) -> DataFrame:
+    async def get_announcement(self) -> pl.DataFrame:
         """翌日発表予定の決算情報を取得する (fins/announcement)。
 
         Returns:
@@ -354,7 +353,7 @@ class JQuantsClient(Client):
         section: str | None = None,
         from_: str | datetime.date | None = None,
         to: str | datetime.date | None = None,
-    ) -> DataFrame:
+    ) -> pl.DataFrame:
         """投資部門別売買状況を取得する (markets/trades_spec)。
 
         Args:
@@ -384,7 +383,7 @@ class JQuantsClient(Client):
         self,
         from_: str | datetime.date | None = None,
         to: str | datetime.date | None = None,
-    ) -> DataFrame:
+    ) -> pl.DataFrame:
         """TOPIXの時系列データを取得する (indices/topix)。
 
         Args:
@@ -414,7 +413,7 @@ class JQuantsClient(Client):
         holidaydivision: str | None = None,
         from_: str | datetime.date | None = None,
         to: str | datetime.date | None = None,
-    ) -> DataFrame:
+    ) -> pl.DataFrame:
         """市場の営業日カレンダーを取得する (markets/trading_calendar)。
 
         Args:

--- a/src/kabukit/sources/jquants/concurrent.py
+++ b/src/kabukit/sources/jquants/concurrent.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import polars as pl
-from polars import DataFrame
 
 from kabukit.utils import concurrent
 
@@ -11,8 +10,6 @@ from .client import JQuantsClient
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-
-    from polars import DataFrame
 
     from kabukit.utils.concurrent import Callback, Progress
 
@@ -25,7 +22,7 @@ async def get(
     max_concurrency: int | None = None,
     progress: Progress | None = None,
     callback: Callback | None = None,
-) -> DataFrame:
+) -> pl.DataFrame:
     """複数の銘柄の各種データを取得し、単一のDataFrameにまとめて返す。
 
     Args:
@@ -62,7 +59,7 @@ async def get(
     return data.sort("Code", "Date")
 
 
-async def get_info(code: str | None = None, /) -> DataFrame:
+async def get_info(code: str | None = None, /) -> pl.DataFrame:
     """上場銘柄一覧を取得する。
 
     Returns:
@@ -104,7 +101,7 @@ async def get_statements(
     max_concurrency: int = 12,
     progress: Progress | None = None,
     callback: Callback | None = None,
-) -> DataFrame:
+) -> pl.DataFrame:
     """四半期毎の決算短信サマリーおよび業績・配当の修正に関する開示情報を取得する。
 
     Args:
@@ -147,7 +144,7 @@ async def get_prices(
     max_concurrency: int = 8,
     progress: Progress | None = None,
     callback: Callback | None = None,
-) -> DataFrame:
+) -> pl.DataFrame:
     """日々の株価四本値を取得する。
 
     株価は分割・併合を考慮した調整済み株価（小数点第２位四捨五入）と調整前の株価を取得できる。

--- a/src/kabukit/sources/jquants/info.py
+++ b/src/kabukit/sources/jquants/info.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import polars as pl
-from polars import DataFrame
 
 
-def clean(df: DataFrame) -> DataFrame:
+def clean(df: pl.DataFrame) -> pl.DataFrame:
     return df.with_columns(
         pl.col("Date").str.to_date("%Y-%m-%d"),
         pl.col("^.*CodeName$", "ScaleCategory").cast(pl.Categorical),

--- a/src/kabukit/sources/jquants/prices.py
+++ b/src/kabukit/sources/jquants/prices.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import polars as pl
 
-if TYPE_CHECKING:
-    from polars import DataFrame
 
-
-def clean(df: DataFrame) -> DataFrame:
+def clean(df: pl.DataFrame) -> pl.DataFrame:
     return df.select(
         pl.col("Date").str.to_date("%Y-%m-%d"),
         "Code",

--- a/src/kabukit/sources/jquants/schema.py
+++ b/src/kabukit/sources/jquants/schema.py
@@ -4,12 +4,13 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from polars import DataFrame
+    import polars as pl
+
 
 
 class BaseColumns(Enum):
     @classmethod
-    def rename(cls, df: DataFrame, *, strict: bool = False) -> DataFrame:
+    def rename(cls, df: pl.DataFrame, *, strict: bool = False) -> pl.DataFrame:
         """DataFrameの列名を日本語から英語に変換する。"""
         return df.rename({x.name: x.value for x in cls}, strict=strict)
 
@@ -170,7 +171,7 @@ class StatementColumns(BaseColumns):
     NextYearForecastNonConsolidatedEarningsPerShare = "一株あたり当期純利益_予想_翌事業年度期末_非連結"
 
 
-def rename(df: DataFrame, *, strict: bool = False) -> DataFrame:
+def rename(df: pl.DataFrame, *, strict: bool = False) -> pl.DataFrame:
     """DataFrameの列名を日本語から英語に変換する。"""
     for enum in (InfoColumns, PriceColumns, StatementColumns):
         df = enum.rename(df, strict=strict)

--- a/src/kabukit/sources/jquants/statements.py
+++ b/src/kabukit/sources/jquants/statements.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING
 
 import polars as pl
 
-if TYPE_CHECKING:
-    from polars import DataFrame
 
-
-def clean(df: DataFrame) -> DataFrame:
+def clean(df: pl.DataFrame) -> pl.DataFrame:
     df = df.select(pl.exclude(r"^.*\(REIT\)$"))
     return df.pipe(_rename).pipe(_cast)
 
 
-def _rename(df: DataFrame) -> DataFrame:
+def _rename(df: pl.DataFrame) -> pl.DataFrame:
     return df.rename(
         {
             "LocalCode": "Code",
@@ -25,7 +21,7 @@ def _rename(df: DataFrame) -> DataFrame:
     )
 
 
-def _cast(df: DataFrame) -> DataFrame:
+def _cast(df: pl.DataFrame) -> pl.DataFrame:
     return (
         df.with_columns(
             pl.col("^.*Date$").str.to_date("%Y-%m-%d", strict=False),
@@ -37,7 +33,7 @@ def _cast(df: DataFrame) -> DataFrame:
     )
 
 
-def _cast_float(df: DataFrame) -> DataFrame:
+def _cast_float(df: pl.DataFrame) -> pl.DataFrame:
     return df.with_columns(
         pl.col(f"^.*{name}.*$").cast(pl.Float64, strict=False)
         for name in [
@@ -63,7 +59,7 @@ def _cast_float(df: DataFrame) -> DataFrame:
     )
 
 
-def _cast_bool(df: DataFrame) -> DataFrame:
+def _cast_bool(df: pl.DataFrame) -> pl.DataFrame:
     columns = df.select(pl.col("^.*Changes.*$")).columns
     columns.append("RetrospectiveRestatement")
 
@@ -78,7 +74,7 @@ def _cast_bool(df: DataFrame) -> DataFrame:
     )
 
 
-def with_date(df: DataFrame, holidays: list[datetime.date]) -> DataFrame:
+def with_date(df: pl.DataFrame, holidays: list[datetime.date]) -> pl.DataFrame:
     """`Date`列を追加する。
 
     開示日が休日のとき、あるいは、開示時刻が15時30分以降の場合、Dateを開示日の翌営業日に設定する。

--- a/src/kabukit/sources/jquants/topix.py
+++ b/src/kabukit/sources/jquants/topix.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import polars as pl
 
-if TYPE_CHECKING:
-    from polars import DataFrame
 
-
-def clean(df: DataFrame) -> DataFrame:
+def clean(df: pl.DataFrame) -> pl.DataFrame:
     return df.select(
         pl.col("Date").str.to_date("%Y-%m-%d"),
         pl.lit("TOPIX").alias("Code"),

--- a/tests/system/edinet/test_client.py
+++ b/tests/system/edinet/test_client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import polars as pl
 import pytest
 import pytest_asyncio
-from polars import DataFrame
 
 from kabukit.sources.edinet.client import EdinetClient
 
@@ -86,15 +85,15 @@ async def df():
     await client.aclose()
 
 
-def test_df_shape(df: DataFrame) -> None:
+def test_df_shape(df: pl.DataFrame) -> None:
     assert df.shape == (1757, 30)
 
 
-def test_df_xbrl_csv(df: DataFrame) -> None:
+def test_df_xbrl_csv(df: pl.DataFrame) -> None:
     df = df.filter(xbrlFlag="1")
     assert df.height == df.filter(csvFlag="1").height
 
 
-def test_df_xbrl_pdf(df: DataFrame) -> None:
+def test_df_xbrl_pdf(df: pl.DataFrame) -> None:
     df = df.filter(xbrlFlag="1")
     assert df.height == df.filter(pdfFlag="1").height

--- a/tests/system/edinet/test_concurrent.py
+++ b/tests/system/edinet/test_concurrent.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from datetime import date
 
+import polars as pl
 import pytest
-from polars import DataFrame
 
 pytestmark = pytest.mark.system
 
@@ -18,8 +18,8 @@ async def test_get() -> None:
     assert df["docID"].n_unique() == 1229  # 重複あり
 
 
-def callback(df: DataFrame) -> DataFrame:
-    assert isinstance(df, DataFrame)
+def callback(df: pl.DataFrame) -> pl.DataFrame:
+    assert isinstance(df, pl.DataFrame)
     return df
 
 

--- a/tests/system/jquants/test_auth.py
+++ b/tests/system/jquants/test_auth.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
+import polars as pl
 import pytest
 from httpx import HTTPStatusError
-from polars import DataFrame
 
 from kabukit.sources.jquants.client import JQuantsClient
 
@@ -74,7 +74,7 @@ async def test_auth_and_get_data(client: JQuantsClient) -> None:
     assert id_token is not None
 
     df = await client.get_info(code="80310")
-    assert isinstance(df, DataFrame)
+    assert isinstance(df, pl.DataFrame)
     assert not df.is_empty()
 
 

--- a/tests/system/jquants/test_calendar.py
+++ b/tests/system/jquants/test_calendar.py
@@ -5,7 +5,6 @@ from datetime import date
 import polars as pl
 import pytest
 import pytest_asyncio
-from polars import DataFrame
 
 from kabukit.sources.jquants.client import JQuantsClient
 
@@ -31,5 +30,5 @@ async def df():
         (date(2025, 10, 14), False),
     ],
 )
-def test_is_holiday(df: DataFrame, d: date, *, is_holiday: bool) -> None:
+def test_is_holiday(df: pl.DataFrame, d: date, *, is_holiday: bool) -> None:
     assert df.filter(pl.col("Date") == d).item(0, "IsHoliday") == is_holiday

--- a/tests/system/jquants/test_concurrent.py
+++ b/tests/system/jquants/test_concurrent.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import marimo as mo
+import polars as pl
 import pytest
-from polars import DataFrame
 
 pytestmark = pytest.mark.system
 
@@ -12,8 +12,8 @@ def resource(request: pytest.FixtureRequest) -> str:
     return request.param
 
 
-def callback(df: DataFrame) -> None:
-    assert isinstance(df, DataFrame)
+def callback(df: pl.DataFrame) -> None:
+    assert isinstance(df, pl.DataFrame)
 
 
 @pytest.mark.asyncio

--- a/tests/system/jquants/test_info.py
+++ b/tests/system/jquants/test_info.py
@@ -6,7 +6,6 @@ from zoneinfo import ZoneInfo
 import polars as pl
 import pytest
 import pytest_asyncio
-from polars import DataFrame
 
 from kabukit.sources.jquants.client import JQuantsClient
 
@@ -39,7 +38,7 @@ async def df():
         yield await client.get_info()
 
 
-def test_width(df: DataFrame) -> None:
+def test_width(df: pl.DataFrame) -> None:
     assert df.height > 4000
     assert df.width in [7, 8]  # 7: ライトプラン, 8: スタンダードプラン
 
@@ -56,11 +55,11 @@ def test_width(df: DataFrame) -> None:
         ("MarketCodeName", pl.Categorical),
     ],
 )
-def test_column_dtype(df: DataFrame, name: str, dtype: type) -> None:
+def test_column_dtype(df: pl.DataFrame, name: str, dtype: type) -> None:
     assert df[name].dtype == dtype
 
 
-def test_today(df: DataFrame) -> None:
+def test_today(df: pl.DataFrame) -> None:
     date = df.item(0, "Date")
     assert isinstance(date, datetime.date)
     today = datetime.datetime.now(ZoneInfo("Asia/Tokyo")).date()
@@ -75,7 +74,7 @@ def test_today(df: DataFrame) -> None:
         ("MarketCodeName", 5),
     ],
 )
-def test_categorical_column_uniqueness(df: DataFrame, name: str, n: int) -> None:
+def test_categorical_column_uniqueness(df: pl.DataFrame, name: str, n: int) -> None:
     assert df[name].n_unique() == n
 
 
@@ -90,17 +89,17 @@ def test_categorical_column_uniqueness(df: DataFrame, name: str, n: int) -> None
         "TOPIX Large70",
     ],
 )
-def test_scale_category(df: DataFrame, sc: str) -> None:
+def test_scale_category(df: pl.DataFrame, sc: str) -> None:
     assert sc in df["ScaleCategory"]
 
 
-def test_columns(df: DataFrame) -> None:
+def test_columns(df: pl.DataFrame) -> None:
     from kabukit.sources.jquants.schema import InfoColumns
 
     assert df.columns == [c.name for c in InfoColumns]
 
 
-def test_rename(df: DataFrame) -> None:
+def test_rename(df: pl.DataFrame) -> None:
     from kabukit.sources.jquants.schema import InfoColumns
 
     df_renamed = InfoColumns.rename(df, strict=True)

--- a/tests/system/jquants/test_prices.py
+++ b/tests/system/jquants/test_prices.py
@@ -5,7 +5,6 @@ import datetime
 import polars as pl
 import pytest
 import pytest_asyncio
-from polars import DataFrame
 
 from kabukit.sources.jquants.client import JQuantsClient
 
@@ -75,7 +74,7 @@ async def df():
         yield await client.get_prices("3671")
 
 
-def test_width(df: DataFrame) -> None:
+def test_width(df: pl.DataFrame) -> None:
     assert df.width == 16
 
 
@@ -100,11 +99,11 @@ def test_width(df: DataFrame) -> None:
         ("RawVolume", pl.Float64),
     ],
 )
-def test_column_dtype(df: DataFrame, name: str, dtype: type) -> None:
+def test_column_dtype(df: pl.DataFrame, name: str, dtype: type) -> None:
     assert df[name].dtype == dtype
 
 
-def test_turnover_value(df: DataFrame) -> None:
+def test_turnover_value(df: pl.DataFrame) -> None:
     a = df["TurnoverValue"]
     b = df["RawHigh"] * df["RawVolume"]
     c = df["RawLow"] * df["RawVolume"]
@@ -112,13 +111,13 @@ def test_turnover_value(df: DataFrame) -> None:
     assert (a >= c).all()
 
 
-def test_columns(df: DataFrame) -> None:
+def test_columns(df: pl.DataFrame) -> None:
     from kabukit.sources.jquants.schema import PriceColumns
 
     assert df.columns == [c.name for c in PriceColumns]
 
 
-def test_rename(df: DataFrame) -> None:
+def test_rename(df: pl.DataFrame) -> None:
     from kabukit.sources.jquants.schema import PriceColumns
 
     df_renamed = PriceColumns.rename(df, strict=True)

--- a/tests/system/jquants/test_statements.py
+++ b/tests/system/jquants/test_statements.py
@@ -5,7 +5,6 @@ import datetime
 import polars as pl
 import pytest
 import pytest_asyncio
-from polars import DataFrame
 
 from kabukit.sources.jquants.client import JQuantsClient
 
@@ -54,18 +53,18 @@ async def df():
         ("NextFiscalYearEndDate", pl.Date),
     ],
 )
-def test_column_dtype(df: DataFrame, name: str, dtype: type) -> None:
+def test_column_dtype(df: pl.DataFrame, name: str, dtype: type) -> None:
     assert df[name].dtype == dtype
 
 
-def test_columns(df: DataFrame) -> None:
+def test_columns(df: pl.DataFrame) -> None:
     from kabukit.sources.jquants.schema import StatementColumns
 
     assert len(df.columns) == len(StatementColumns)
     assert df.columns == [c.name for c in StatementColumns]
 
 
-def test_rename(df: DataFrame) -> None:
+def test_rename(df: pl.DataFrame) -> None:
     from kabukit.sources.jquants.schema import StatementColumns
 
     df_renamed = StatementColumns.rename(df, strict=True)
@@ -91,7 +90,7 @@ async def test_column_names(prefix: str) -> None:
     ],
 )
 def test_with_date(
-    df: DataFrame,
+    df: pl.DataFrame,
     code: str,
     date: datetime.date,
     time: datetime.time,

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
+import polars as pl
 import pytest
-from polars import DataFrame
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
     from pytest_mock import MockerFixture
 
-MOCK_DF = DataFrame({"A": [1, 2], "B": [3, 4]})
+MOCK_DF = pl.DataFrame({"A": [1, 2], "B": [3, 4]})
 MOCK_CODE = "1234"
 MOCK_PATH = "fake/path.csv"
 

--- a/tests/unit/domain/jquants/test_prices.py
+++ b/tests/unit/domain/jquants/test_prices.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 import pytest
-from polars import DataFrame, Series
 from polars.testing import assert_frame_equal
 
 from kabukit.domain.jquants.prices import Prices
@@ -18,8 +17,8 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture(scope="module")
-def data() -> DataFrame:
-    return DataFrame(
+def data() -> pl.DataFrame:
+    return pl.DataFrame(
         {
             "Date": [
                 date(2023, 1, 1),
@@ -42,13 +41,13 @@ def data() -> DataFrame:
     )
 
 
-def test_truncate_day(data: DataFrame) -> None:
+def test_truncate_day(data: pl.DataFrame) -> None:
     prices = Prices(data)
     df = prices.truncate("1d").data
     assert df.equals(data)
 
 
-def test_truncate_month(data: DataFrame) -> None:
+def test_truncate_month(data: pl.DataFrame) -> None:
     prices = Prices(data)
     df = prices.truncate("1mo").data
     assert df.shape == (4, 8)
@@ -68,7 +67,7 @@ def test_truncate_month(data: DataFrame) -> None:
 
 
 def test_with_adjusted_shares() -> None:
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [
                 date(2023, 5, 1),
@@ -83,7 +82,7 @@ def test_with_adjusted_shares() -> None:
         },
     )
 
-    statements_df = DataFrame(
+    statements_df = pl.DataFrame(
         {
             "Date": [
                 date(2023, 3, 31),
@@ -102,7 +101,7 @@ def test_with_adjusted_shares() -> None:
 
     expected = prices_df.with_columns(
         [
-            Series(
+            pl.Series(
                 "ReportDate",
                 [
                     date(2023, 3, 31),
@@ -114,12 +113,12 @@ def test_with_adjusted_shares() -> None:
                 ],
                 dtype=pl.Date,
             ),
-            Series(
+            pl.Series(
                 "AdjustedIssuedShares",
                 [1000, 2400, 12000, None, 2000, 1000],
                 dtype=pl.Int64,
             ),
-            Series(
+            pl.Series(
                 "AdjustedTreasuryShares",
                 [100, 240, 1200, None, 200, 100],
                 dtype=pl.Int64,
@@ -133,7 +132,7 @@ def test_with_adjusted_shares() -> None:
 
 
 def test_with_market_cap() -> None:
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [
                 date(2023, 1, 1),
@@ -152,14 +151,14 @@ def test_with_market_cap() -> None:
     result = prices.with_market_cap()
 
     expected = prices_df.with_columns(
-        Series("MarketCap", [90000.0, 99000.0, 216000.0]),
+        pl.Series("MarketCap", [90000.0, 99000.0, 216000.0]),
     )
 
     assert_frame_equal(result.data, expected)
 
 
 def test_with_equity() -> None:
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [
                 date(2023, 4, 1),
@@ -172,7 +171,7 @@ def test_with_equity() -> None:
         },
     )
 
-    statements_df = DataFrame(
+    statements_df = pl.DataFrame(
         {
             "Date": [
                 date(2023, 3, 31),
@@ -190,14 +189,14 @@ def test_with_equity() -> None:
     result = prices.with_equity(statements)
 
     expected = prices_df.with_columns(
-        Series("Equity", [1000.0, 1000.0, 1000.0, None, 2000.0], dtype=pl.Float64),
+        pl.Series("Equity", [1000.0, 1000.0, 1000.0, None, 2000.0], dtype=pl.Float64),
     )
 
     assert_frame_equal(result.data, expected)
 
 
 def test_with_book_value_yield() -> None:
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [date(2023, 1, 1), date(2023, 1, 2)],
             "Code": ["A", "A"],
@@ -214,8 +213,8 @@ def test_with_book_value_yield() -> None:
 
     expected = prices_df.with_columns(
         [
-            Series("BookValuePerShare", [1111.11, 1111.11]),
-            Series("BookValueYield", [1.1111, 0.8889]),
+            pl.Series("BookValuePerShare", [1111.11, 1111.11]),
+            pl.Series("BookValueYield", [1.1111, 0.8889]),
         ],
     )
 
@@ -223,7 +222,7 @@ def test_with_book_value_yield() -> None:
 
 
 def test_with_forecast_profit() -> None:
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [
                 date(2023, 4, 1),
@@ -236,7 +235,7 @@ def test_with_forecast_profit() -> None:
         },
     )
 
-    statements_df = DataFrame(
+    statements_df = pl.DataFrame(
         {
             "Date": [
                 date(2023, 5, 1),
@@ -256,14 +255,14 @@ def test_with_forecast_profit() -> None:
     result = prices.with_forecast_profit(statements)
 
     expected = prices_df.with_columns(
-        Series("ForecastProfit", [None, 100.0, 150.0, None, 200.0]),
+        pl.Series("ForecastProfit", [None, 100.0, 150.0, None, 200.0]),
     )
 
     assert_frame_equal(result.data, expected)
 
 
 def test_with_earnings_yield() -> None:
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [date(2023, 1, 1), date(2023, 1, 2)],
             "Code": ["A", "A"],
@@ -280,8 +279,8 @@ def test_with_earnings_yield() -> None:
 
     expected = prices_df.with_columns(
         [
-            Series("EarningsPerShare", [111.1111, 111.1111]),
-            Series("EarningsYield", [0.055556, 0.061728]),
+            pl.Series("EarningsPerShare", [111.1111, 111.1111]),
+            pl.Series("EarningsYield", [0.055556, 0.061728]),
         ],
     )
 
@@ -289,7 +288,7 @@ def test_with_earnings_yield() -> None:
 
 
 def test_with_forecast_dividend() -> None:
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [
                 date(2023, 4, 1),
@@ -302,7 +301,7 @@ def test_with_forecast_dividend() -> None:
         },
     ).sort("Code", "Date")
 
-    statements_df = DataFrame(
+    statements_df = pl.DataFrame(
         {
             "Date": [
                 date(2023, 5, 1),
@@ -326,14 +325,14 @@ def test_with_forecast_dividend() -> None:
     result = prices.with_forecast_dividend(statements)
 
     expected = prices_df.with_columns(
-        Series("ForecastDividend", [None, 500.0, 900.0, None, 2000.0]),
+        pl.Series("ForecastDividend", [None, 500.0, 900.0, None, 2000.0]),
     )
 
     assert_frame_equal(result.data, expected)
 
 
 def test_with_dividend_yield() -> None:
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [date(2023, 1, 1), date(2023, 1, 2)],
             "Code": ["A", "A"],
@@ -350,8 +349,8 @@ def test_with_dividend_yield() -> None:
 
     expected = prices_df.with_columns(
         [
-            Series("DividendPerShare", [50.0, 50.0]),
-            Series("DividendYield", [0.05, 0.04545454]),
+            pl.Series("DividendPerShare", [50.0, 50.0]),
+            pl.Series("DividendYield", [0.05, 0.04545454]),
         ],
     )
 
@@ -382,7 +381,7 @@ def test_data_loading_methods_are_idempotent(
     statements_return_cols: list[str],
 ) -> None:
     """データロードメソッドがべき等であることを検証する"""
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [date(2023, 1, 1)],
             "Code": ["A"],
@@ -392,7 +391,7 @@ def test_data_loading_methods_are_idempotent(
     )
     prices = Prices(prices_df)
 
-    statements = Statements(DataFrame({"Date": [date(2023, 1, 1)], "Code": ["A"]}))
+    statements = Statements(pl.DataFrame({"Date": [date(2023, 1, 1)], "Code": ["A"]}))
 
     mock_data = {}
     for col in statements_return_cols:
@@ -403,7 +402,7 @@ def test_data_loading_methods_are_idempotent(
         else:
             mock_data[col] = [1.0]  # その他のデータカラムはfloat
 
-    mock_return_df = DataFrame(mock_data)
+    mock_return_df = pl.DataFrame(mock_data)
 
     mocker.patch.object(
         statements,
@@ -431,7 +430,7 @@ def test_data_loading_methods_are_idempotent(
 )
 def test_methods_raise_key_error_without_adjusted_shares(method_name: str) -> None:
     """前提条件となる adjusted_shares がない場合にKeyErrorを送出する"""
-    prices_df = DataFrame({"Code": ["A"]})  # `Adjusted...Shares` 列を持たない
+    prices_df = pl.DataFrame({"Code": ["A"]})  # `Adjusted...Shares` 列を持たない
     prices = Prices(prices_df)
 
     method = getattr(prices, method_name)
@@ -441,7 +440,7 @@ def test_methods_raise_key_error_without_adjusted_shares(method_name: str) -> No
 
 
 def test_with_yields() -> None:
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [date(2023, 1, 1)],
             "Code": ["A"],
@@ -450,7 +449,7 @@ def test_with_yields() -> None:
         },
     )
 
-    statements_df = DataFrame(
+    statements_df = pl.DataFrame(
         {
             "Date": [date(2023, 1, 1)],
             "Code": ["A"],
@@ -475,18 +474,18 @@ def test_with_yields() -> None:
 
     expected_df = prices_df.with_columns(
         [
-            Series("ReportDate", [date(2023, 1, 1)], dtype=pl.Date),
-            Series("AdjustedIssuedShares", [1000], dtype=pl.Int64),
-            Series("AdjustedTreasuryShares", [100], dtype=pl.Int64),
-            Series("Equity", [900000.0]),
-            Series("BookValuePerShare", [1000.0]),
-            Series("BookValueYield", [1.0]),
-            Series("ForecastProfit", [90000.0]),
-            Series("EarningsPerShare", [100.0]),
-            Series("EarningsYield", [0.1]),
-            Series("ForecastDividend", [45000.0]),
-            Series("DividendPerShare", [50.0]),
-            Series("DividendYield", [0.05]),
+            pl.Series("ReportDate", [date(2023, 1, 1)], dtype=pl.Date),
+            pl.Series("AdjustedIssuedShares", [1000], dtype=pl.Int64),
+            pl.Series("AdjustedTreasuryShares", [100], dtype=pl.Int64),
+            pl.Series("Equity", [900000.0]),
+            pl.Series("BookValuePerShare", [1000.0]),
+            pl.Series("BookValueYield", [1.0]),
+            pl.Series("ForecastProfit", [90000.0]),
+            pl.Series("EarningsPerShare", [100.0]),
+            pl.Series("EarningsYield", [0.1]),
+            pl.Series("ForecastDividend", [45000.0]),
+            pl.Series("DividendPerShare", [50.0]),
+            pl.Series("DividendYield", [0.05]),
         ],
     )
 
@@ -494,7 +493,7 @@ def test_with_yields() -> None:
 
 
 def test_with_period_stats() -> None:
-    prices_df = DataFrame(
+    prices_df = pl.DataFrame(
         {
             "Date": [date(2023, 1, 1)],
             "Code": ["A"],
@@ -503,7 +502,7 @@ def test_with_period_stats() -> None:
             "AdjustmentFactor": [1.0],
         },
     )
-    statements_df = DataFrame(
+    statements_df = pl.DataFrame(
         {
             "Date": [date(2023, 1, 1)],
             "Code": ["A"],
@@ -529,26 +528,26 @@ def test_with_period_stats() -> None:
 
     expected_df = processed_prices.data.with_columns(
         [
-            Series("BookValueYield_PeriodOpen", [1.0]),
-            Series("BookValueYield_PeriodHigh", [1.0]),
-            Series("BookValueYield_PeriodLow", [1.0]),
-            Series("BookValueYield_PeriodClose", [1.0]),
-            Series("BookValueYield_PeriodMean", [1.0]),
-            Series("EarningsYield_PeriodOpen", [1.0]),
-            Series("EarningsYield_PeriodHigh", [1.0]),
-            Series("EarningsYield_PeriodLow", [1.0]),
-            Series("EarningsYield_PeriodClose", [1.0]),
-            Series("EarningsYield_PeriodMean", [1.0]),
-            Series("DividendYield_PeriodOpen", [0.5]),
-            Series("DividendYield_PeriodHigh", [0.5]),
-            Series("DividendYield_PeriodLow", [0.5]),
-            Series("DividendYield_PeriodClose", [0.5]),
-            Series("DividendYield_PeriodMean", [0.5]),
-            Series("Close_PeriodOpen", [100.0]),
-            Series("Close_PeriodHigh", [100.0]),
-            Series("Close_PeriodLow", [100.0]),
-            Series("Close_PeriodClose", [100.0]),
-            Series("Close_PeriodMean", [100.0]),
+            pl.Series("BookValueYield_PeriodOpen", [1.0]),
+            pl.Series("BookValueYield_PeriodHigh", [1.0]),
+            pl.Series("BookValueYield_PeriodLow", [1.0]),
+            pl.Series("BookValueYield_PeriodClose", [1.0]),
+            pl.Series("BookValueYield_PeriodMean", [1.0]),
+            pl.Series("EarningsYield_PeriodOpen", [1.0]),
+            pl.Series("EarningsYield_PeriodHigh", [1.0]),
+            pl.Series("EarningsYield_PeriodLow", [1.0]),
+            pl.Series("EarningsYield_PeriodClose", [1.0]),
+            pl.Series("EarningsYield_PeriodMean", [1.0]),
+            pl.Series("DividendYield_PeriodOpen", [0.5]),
+            pl.Series("DividendYield_PeriodHigh", [0.5]),
+            pl.Series("DividendYield_PeriodLow", [0.5]),
+            pl.Series("DividendYield_PeriodClose", [0.5]),
+            pl.Series("DividendYield_PeriodMean", [0.5]),
+            pl.Series("Close_PeriodOpen", [100.0]),
+            pl.Series("Close_PeriodHigh", [100.0]),
+            pl.Series("Close_PeriodLow", [100.0]),
+            pl.Series("Close_PeriodClose", [100.0]),
+            pl.Series("Close_PeriodMean", [100.0]),
         ],
     )
 
@@ -556,6 +555,6 @@ def test_with_period_stats() -> None:
 
 
 def test_period_stats_raise_key_error_without_required_columns() -> None:
-    prices = Prices(DataFrame({"Code": ["A"]}))
+    prices = Prices(pl.DataFrame({"Code": ["A"]}))
     with pytest.raises(KeyError, match="必要な列が存在しません"):
         prices.with_period_stats()

--- a/tests/unit/domain/jquants/test_statements.py
+++ b/tests/unit/domain/jquants/test_statements.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import polars as pl
 import pytest
-from polars import DataFrame
 from polars.testing import assert_frame_equal
 
 from kabukit.domain.jquants.statements import Statements
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.unit
 
 
 def test_shares() -> None:
-    data = DataFrame(
+    data = pl.DataFrame(
         {
             "Date": [1, 2],
             "Code": [3, 4],
@@ -23,7 +23,7 @@ def test_shares() -> None:
 
     result = Statements(data).shares()
 
-    expected = DataFrame(
+    expected = pl.DataFrame(
         {
             "Date": [1],
             "Code": [3],
@@ -36,7 +36,7 @@ def test_shares() -> None:
 
 
 def test_forecast_profit() -> None:
-    data = DataFrame(
+    data = pl.DataFrame(
         {
             "Date": [1, 2, 1, 2],
             "Code": [1, 1, 2, 2],
@@ -48,7 +48,7 @@ def test_forecast_profit() -> None:
 
     result = Statements(data).forecast_profit()
 
-    expected = DataFrame(
+    expected = pl.DataFrame(
         {
             "Date": [2, 1, 2],
             "Code": [1, 2, 2],
@@ -60,7 +60,7 @@ def test_forecast_profit() -> None:
 
 
 def test_forecast_dividend() -> None:
-    data = DataFrame(
+    data = pl.DataFrame(
         {
             "Date": [1, 2, 3, 4, 5],
             "Code": [1, 1, 2, 2, 3],
@@ -76,7 +76,7 @@ def test_forecast_dividend() -> None:
 
     result = Statements(data).forecast_dividend()
 
-    expected = DataFrame(
+    expected = pl.DataFrame(
         {
             "Date": [1, 2, 3, 4],
             "Code": [1, 1, 2, 2],
@@ -88,7 +88,7 @@ def test_forecast_dividend() -> None:
 
 
 def test_equity() -> None:
-    data = DataFrame(
+    data = pl.DataFrame(
         {
             "Date": [1, 2, 1],
             "Code": ["A", "A", "B"],
@@ -99,7 +99,7 @@ def test_equity() -> None:
 
     result = Statements(data).equity()
 
-    expected = DataFrame(
+    expected = pl.DataFrame(
         {
             "Date": [1, 1],
             "Code": ["A", "B"],

--- a/tests/unit/domain/test_base.py
+++ b/tests/unit/domain/test_base.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 import pytest
-from polars import DataFrame
 from polars.testing import assert_frame_equal
 
 from kabukit.domain.base import Base
@@ -17,11 +16,11 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
-def data() -> DataFrame:
-    return DataFrame({"A": [1, 2], "B": ["x", "y"]})
+def data() -> pl.DataFrame:
+    return pl.DataFrame({"A": [1, 2], "B": ["x", "y"]})
 
 
-def test_init(data: DataFrame) -> None:
+def test_init(data: pl.DataFrame) -> None:
     assert_frame_equal(Base(data).data, data)
 
 
@@ -38,7 +37,7 @@ def test_data_dir(mocker: MockerFixture) -> None:
     assert Derived.data_dir() == Path("cache") / "jquants" / "derived"
 
 
-def test_write_no_name(mocker: MockerFixture, data: DataFrame) -> None:
+def test_write_no_name(mocker: MockerFixture, data: pl.DataFrame) -> None:
     mocker.patch.object(Derived, "__module__", "kabukit.domain.jquants.derived")
     mock_cache_write = mocker.patch(
         "kabukit.domain.cache.write",
@@ -49,7 +48,7 @@ def test_write_no_name(mocker: MockerFixture, data: DataFrame) -> None:
     mock_cache_write.assert_called_once_with("jquants", "derived", data, None)
 
 
-def test_write_with_name(mocker: MockerFixture, data: DataFrame) -> None:
+def test_write_with_name(mocker: MockerFixture, data: pl.DataFrame) -> None:
     mocker.patch.object(Derived, "__module__", "kabukit.domain.jquants.derived")
     mock_cache_write = mocker.patch(
         "kabukit.domain.cache.write",
@@ -60,7 +59,7 @@ def test_write_with_name(mocker: MockerFixture, data: DataFrame) -> None:
     mock_cache_write.assert_called_once_with("jquants", "derived", data, "my_file")
 
 
-def test_init_from_cache(mocker: MockerFixture, data: DataFrame) -> None:
+def test_init_from_cache(mocker: MockerFixture, data: pl.DataFrame) -> None:
     mocker.patch.object(Derived, "__module__", "kabukit.domain.jquants.derived")
     mock_cache_read = mocker.patch("kabukit.domain.cache.read", return_value=data)
 
@@ -80,6 +79,6 @@ def test_init_from_cache_file_not_found(mocker: MockerFixture) -> None:
         Derived()
 
 
-def test_filter(data: DataFrame) -> None:
-    expected = DataFrame({"A": [1], "B": ["x"]})
+def test_filter(data: pl.DataFrame) -> None:
+    expected = pl.DataFrame({"A": [1], "B": ["x"]})
     assert_frame_equal(Derived(data).filter(pl.col("A") == 1).data, expected)

--- a/tests/unit/domain/test_cache.py
+++ b/tests/unit/domain/test_cache.py
@@ -9,7 +9,6 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
-from polars import DataFrame
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -223,7 +222,7 @@ def test_read(mocker: MockerFixture, tmp_path: Path) -> None:
     cache_dir = tmp_path / "jquants" / "test"
     cache_dir.mkdir(parents=True)
 
-    data = DataFrame({"A": [1, 2], "B": ["x", "y"]})
+    data = pl.DataFrame({"A": [1, 2], "B": ["x", "y"]})
     data.write_parquet(cache_dir / "my_file.parquet")
 
     result = read("jquants", "test", name="my_file")
@@ -236,7 +235,7 @@ def test_write_no_name(mocker: MockerFixture, tmp_path: Path) -> None:
     mock_get_cache_dir = mocker.patch("kabukit.domain.cache.get_cache_dir")
     mock_get_cache_dir.return_value = tmp_path
 
-    data = DataFrame({"A": [1, 2], "B": ["x", "y"]})
+    data = pl.DataFrame({"A": [1, 2], "B": ["x", "y"]})
     path = write("jquants", "test", data)
 
     assert path.exists()
@@ -253,7 +252,7 @@ def test_write_with_name(mocker: MockerFixture, tmp_path: Path) -> None:
     mock_get_cache_dir = mocker.patch("kabukit.domain.cache.get_cache_dir")
     mock_get_cache_dir.return_value = tmp_path
 
-    data = DataFrame({"A": [1, 2], "B": ["x", "y"]})
+    data = pl.DataFrame({"A": [1, 2], "B": ["x", "y"]})
     path = write("jquants", "test", data, name="my_file")
 
     assert path.exists()

--- a/tests/unit/sources/edinet/test_client.py
+++ b/tests/unit/sources/edinet/test_client.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 from httpx import ConnectTimeout, HTTPStatusError, Response
-from polars import DataFrame
 from polars.testing import assert_frame_equal
 
 from kabukit.sources.edinet.client import AuthKey, EdinetClient
@@ -192,7 +191,7 @@ async def test_get_pdf_success(mock_get: AsyncMock, mocker: MockerFixture) -> No
     client = EdinetClient("test_key")
     df = await client.get_pdf("S100TEST")
 
-    expected = DataFrame({"docID": ["S100TEST"], "pdf": [b"pdf content"]})
+    expected = pl.DataFrame({"docID": ["S100TEST"], "pdf": [b"pdf content"]})
 
     assert_frame_equal(df, expected)
     mock_get.assert_awaited_once_with("/documents/S100TEST", params={"type": 2})
@@ -333,7 +332,7 @@ async def test_get_document_calls_get_csv_by_default(mocker: MockerFixture) -> N
     mock_get_csv = mocker.patch.object(client, "get_csv", new_callable=mocker.AsyncMock)
     mock_get_pdf = mocker.patch.object(client, "get_pdf", new_callable=mocker.AsyncMock)
 
-    expected_df = DataFrame({"col": ["csv_data"]})
+    expected_df = pl.DataFrame({"col": ["csv_data"]})
     mock_get_csv.return_value = expected_df
 
     doc_id = "S100TEST"
@@ -352,7 +351,7 @@ async def test_get_document_calls_get_pdf_when_pdf_is_true(
     mock_get_csv = mocker.patch.object(client, "get_csv", new_callable=mocker.AsyncMock)
     mock_get_pdf = mocker.patch.object(client, "get_pdf", new_callable=mocker.AsyncMock)
 
-    expected_df = DataFrame({"col": ["pdf_data"]})
+    expected_df = pl.DataFrame({"col": ["pdf_data"]})
     mock_get_pdf.return_value = expected_df
 
     doc_id = "S100TEST"

--- a/tests/unit/sources/edinet/test_concurrent.py
+++ b/tests/unit/sources/edinet/test_concurrent.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING
 
+import polars as pl
 import pytest
-from polars import DataFrame
 
 from kabukit.sources.edinet.client import EdinetClient
 
@@ -22,7 +22,7 @@ def dummy_progress(x: Iterable[Any]) -> Iterable[Any]:
     return x
 
 
-def dummy_callback(df: DataFrame) -> DataFrame:
+def dummy_callback(df: pl.DataFrame) -> pl.DataFrame:
     return df
 
 
@@ -38,7 +38,7 @@ def mock_utils_get(mocker: MockerFixture) -> AsyncMock:
 async def test_get(mock_utils_get: AsyncMock) -> None:
     from kabukit.sources.edinet.concurrent import get
 
-    mock_utils_get.return_value = DataFrame({"a": [1]})
+    mock_utils_get.return_value = pl.DataFrame({"a": [1]})
 
     result = await get(
         "test_resource",
@@ -48,7 +48,7 @@ async def test_get(mock_utils_get: AsyncMock) -> None:
         callback=dummy_callback,
     )
 
-    assert result.equals(DataFrame({"a": [1]}))
+    assert result.equals(pl.DataFrame({"a": [1]}))
     mock_utils_get.assert_awaited_once_with(
         EdinetClient,
         "test_resource",
@@ -81,7 +81,7 @@ async def test_get_entries_days(
         "kabukit.sources.edinet.concurrent.get",
         new_callable=mocker.AsyncMock,
     )
-    mock_get.return_value = DataFrame({"Date": [2], "Code": ["10000"]})
+    mock_get.return_value = pl.DataFrame({"Date": [2], "Code": ["10000"]})
 
     result = await get_entries(
         days=3,
@@ -91,7 +91,7 @@ async def test_get_entries_days(
         callback=dummy_callback,
     )
 
-    assert result.equals(DataFrame({"Date": [2], "Code": ["10000"]}))
+    assert result.equals(pl.DataFrame({"Date": [2], "Code": ["10000"]}))
     mock_get_dates.assert_called_once_with(days=3, years=None)
     mock_get.assert_awaited_once_with(
         "entries",
@@ -122,7 +122,7 @@ async def test_get_entries_years(
         "kabukit.sources.edinet.concurrent.get",
         new_callable=mocker.AsyncMock,
     )
-    mock_get.return_value = DataFrame({"Date": [1], "Code": ["10000"]})
+    mock_get.return_value = pl.DataFrame({"Date": [1], "Code": ["10000"]})
 
     await get_entries(years=2)
 
@@ -158,7 +158,7 @@ async def test_get_entries_invalid_date(mocker: MockerFixture) -> None:
         "kabukit.sources.edinet.concurrent.get",
         new_callable=mocker.AsyncMock,
     )
-    mock_get.return_value = DataFrame()
+    mock_get.return_value = pl.DataFrame()
 
     result = await get_entries(["2025-10-10"])
     assert result.is_empty()
@@ -172,7 +172,7 @@ async def test_get_documents_csv(mocker: MockerFixture) -> None:
         "kabukit.sources.edinet.concurrent.get",
         new_callable=mocker.AsyncMock,
     )
-    mock_get.return_value = DataFrame({"docID": [3]})
+    mock_get.return_value = pl.DataFrame({"docID": [3]})
 
     result = await get_documents(
         ["doc1", "doc2", "doc3"],
@@ -182,7 +182,7 @@ async def test_get_documents_csv(mocker: MockerFixture) -> None:
         callback=dummy_callback,
     )
 
-    assert result.equals(DataFrame({"docID": [3]}))
+    assert result.equals(pl.DataFrame({"docID": [3]}))
     mock_get.assert_awaited_once_with(
         "csv",
         ["doc1", "doc2", "doc3"],
@@ -201,7 +201,7 @@ async def test_get_documents_pdf(mocker: MockerFixture) -> None:
         "kabukit.sources.edinet.concurrent.get",
         new_callable=mocker.AsyncMock,
     )
-    mock_get.return_value = DataFrame({"docID": [1]})
+    mock_get.return_value = pl.DataFrame({"docID": [1]})
 
     await get_documents(["doc1", "doc2"], pdf=True)
 

--- a/tests/unit/sources/edinet/test_doc.py
+++ b/tests/unit/sources/edinet/test_doc.py
@@ -5,14 +5,13 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
-from polars import DataFrame
 
 pytestmark = pytest.mark.unit
 
 
 @pytest.fixture(scope="module")
-def df() -> DataFrame:
-    return DataFrame(
+def df() -> pl.DataFrame:
+    return pl.DataFrame(
         {
             "csvFlag": ["1", "0"],
             "pdfFlag": ["1", "0"],
@@ -25,7 +24,7 @@ def df() -> DataFrame:
     )
 
 
-def test_clean_entries_columns(df: DataFrame) -> None:
+def test_clean_entries_columns(df: pl.DataFrame) -> None:
     from kabukit.sources.edinet.doc import clean_entries
 
     df = clean_entries(df, "2025-09-19")
@@ -42,7 +41,7 @@ def test_clean_entries_columns(df: DataFrame) -> None:
 
 
 @pytest.mark.parametrize("d", ["2025-09-19", date(2025, 9, 19)])
-def test_clean_entries_date_time(df: DataFrame, d: str | date) -> None:
+def test_clean_entries_date_time(df: pl.DataFrame, d: str | date) -> None:
     from kabukit.sources.edinet.doc import clean_entries
 
     df = clean_entries(df, d)
@@ -57,7 +56,7 @@ def test_clean_entries_date_time(df: DataFrame, d: str | date) -> None:
 def test_clean_entries_date_time_null() -> None:
     from kabukit.sources.edinet.doc import clean_entries
 
-    df = DataFrame(
+    df = pl.DataFrame(
         {
             "submitDateTime": ["", None],
             "opeDateTime": ["", ""],
@@ -70,7 +69,7 @@ def test_clean_entries_date_time_null() -> None:
     assert df["opeDateTime"].dtype == pl.Datetime
 
 
-def test_clean_entries_flag(df: DataFrame) -> None:
+def test_clean_entries_flag(df: pl.DataFrame) -> None:
     from kabukit.sources.edinet.doc import clean_entries
 
     df = clean_entries(df, "2025-09-19")
@@ -78,7 +77,7 @@ def test_clean_entries_flag(df: DataFrame) -> None:
     assert df["pdfFlag"].to_list() == [True, False]
 
 
-def test_clean_entries_period(df: DataFrame) -> None:
+def test_clean_entries_period(df: pl.DataFrame) -> None:
     from kabukit.sources.edinet.doc import clean_entries
 
     df = clean_entries(df, "2025-09-19")
@@ -86,7 +85,7 @@ def test_clean_entries_period(df: DataFrame) -> None:
     assert df["periodEnd"].to_list() == [date(2025, 9, 30), None]
 
 
-def test_clean_entries_ope_datetime(df: DataFrame) -> None:
+def test_clean_entries_ope_datetime(df: pl.DataFrame) -> None:
     from kabukit.sources.edinet.doc import clean_entries
 
     df = clean_entries(df, "2025-09-19")
@@ -108,7 +107,7 @@ def test_clean_pdf() -> None:
 def test_clean_csv() -> None:
     from kabukit.sources.edinet.doc import clean_csv
 
-    df = DataFrame({"a": [1, 2]})
+    df = pl.DataFrame({"a": [1, 2]})
     df = clean_csv(df, "abc")
     assert df.columns == ["docID", "a"]
     assert df["docID"].to_list() == ["abc", "abc"]

--- a/tests/unit/sources/jquants/test_calendar.py
+++ b/tests/unit/sources/jquants/test_calendar.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 from httpx import Response
-from polars import DataFrame
 from polars.testing import assert_frame_equal
 
 from kabukit.sources.jquants.client import JQuantsClient
@@ -41,7 +40,7 @@ async def test_get_calendar(mock_get: AsyncMock, mocker: MockerFixture) -> None:
 
     # 3. Assert the result
     expected_df = (
-        DataFrame(
+        pl.DataFrame(
             {
                 "Date": [
                     datetime.date(2025, 10, 6),

--- a/tests/unit/sources/jquants/test_concurrent.py
+++ b/tests/unit/sources/jquants/test_concurrent.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import polars as pl
 import pytest
-from polars import DataFrame
 
 from kabukit.sources.jquants.client import JQuantsClient
 
@@ -21,7 +21,7 @@ def dummy_progress(x: Iterable[Any]) -> Iterable[Any]:
     return x
 
 
-def dummy_callback(df: DataFrame) -> DataFrame:
+def dummy_callback(df: pl.DataFrame) -> pl.DataFrame:
     return df
 
 
@@ -53,7 +53,7 @@ def mock_get_info(mocker: MockerFixture) -> AsyncMock:
 async def test_get(mock_utils_get: AsyncMock) -> None:
     from kabukit.sources.jquants.concurrent import get
 
-    mock_utils_get.return_value = DataFrame(
+    mock_utils_get.return_value = pl.DataFrame(
         {"Date": [4, 3, 2, 1], "Code": ["a", "b", "b", "a"]},
     )
 
@@ -65,7 +65,7 @@ async def test_get(mock_utils_get: AsyncMock) -> None:
         callback=dummy_callback,
     )
 
-    expected = DataFrame({"Date": [1, 4, 2, 3], "Code": ["a", "a", "b", "b"]})
+    expected = pl.DataFrame({"Date": [1, 4, 2, 3], "Code": ["a", "a", "b", "b"]})
     assert result.equals(expected)
 
     mock_utils_get.assert_awaited_once_with(
@@ -88,7 +88,7 @@ async def test_get_without_codes(
 
     mock_get_target_codes.return_value = ["1111", "2222", "3333"]
     # get() は .sort("Code", "Date") を行うので、モックの戻り値にもカラムが必要
-    mock_utils_get.return_value = DataFrame(
+    mock_utils_get.return_value = pl.DataFrame(
         {"Date": [1], "Code": ["c"], "b": [2]},
     )
 
@@ -102,7 +102,7 @@ async def test_get_without_codes(
     )
 
     # ソート後の結果を期待値とする
-    expected = DataFrame({"Date": [1], "Code": ["c"], "b": [2]})
+    expected = pl.DataFrame({"Date": [1], "Code": ["c"], "b": [2]})
     assert result.equals(expected)
 
     mock_get_target_codes.assert_awaited_once()
@@ -130,7 +130,7 @@ async def test_get_info(mock_jquants_client_context: AsyncMock) -> None:
 async def test_get_target_codes(mock_get_info: AsyncMock) -> None:
     from kabukit.sources.jquants.concurrent import get_target_codes
 
-    mock_df = DataFrame(
+    mock_df = pl.DataFrame(
         {
             "Code": ["0001", "0002", "0003", "0004", "0005"],
             "MarketCodeName": [

--- a/tests/unit/sources/jquants/test_info.py
+++ b/tests/unit/sources/jquants/test_info.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 from httpx import Response
-from polars import DataFrame
 
 from kabukit.sources.jquants.client import JQuantsClient
 
@@ -33,7 +32,7 @@ async def test_get_info(mock_get: AsyncMock, mocker: MockerFixture) -> None:
 def test_clean() -> None:
     from kabukit.sources.jquants.info import clean
 
-    df = DataFrame(
+    df = pl.DataFrame(
         {
             "Date": ["2023-01-01", "2023-01-02"],
             "ACodeName": ["A", "B"],

--- a/tests/unit/sources/jquants/test_prices.py
+++ b/tests/unit/sources/jquants/test_prices.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 import polars as pl
 import pytest
 from httpx import Response
-from polars import DataFrame
 
 from kabukit.sources.jquants.client import JQuantsClient
 
@@ -54,10 +53,10 @@ async def test_error(client: JQuantsClient) -> None:
 
 
 @pytest.fixture
-def df() -> DataFrame:
+def df() -> pl.DataFrame:
     from kabukit.sources.jquants.prices import clean
 
-    return DataFrame(
+    return pl.DataFrame(
         {
             "Date": ["2023-01-01", "2023-01-02"],
             "Code": ["1300", "1301"],
@@ -79,11 +78,11 @@ def df() -> DataFrame:
     ).pipe(clean)
 
 
-def test_clean_shape(df: DataFrame) -> None:
+def test_clean_shape(df: pl.DataFrame) -> None:
     assert df.shape == (2, 16)
 
 
-def test_clean_date(df: DataFrame) -> None:
+def test_clean_date(df: pl.DataFrame) -> None:
     assert df["Date"].dtype == pl.Date
 
 
@@ -106,5 +105,5 @@ def test_clean_date(df: DataFrame) -> None:
         ("RawVolume", [9, 10]),
     ],
 )
-def test_clean(df: DataFrame, column: str, values: list[Any]) -> None:
+def test_clean(df: pl.DataFrame, column: str, values: list[Any]) -> None:
     assert df[column].to_list() == values

--- a/tests/unit/sources/jquants/test_schema.py
+++ b/tests/unit/sources/jquants/test_schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import polars as pl
 import pytest
-from polars import DataFrame
 
 from kabukit.sources.jquants.schema import (
     InfoColumns,
@@ -34,7 +34,7 @@ def test_rename_all_columns() -> None:
         "TotalAssets": [2000000],
         "Equity": [1200000],
     }
-    df = DataFrame(test_data)
+    df = pl.DataFrame(test_data)
 
     # 変換を実行
     renamed_df = rename(df)

--- a/tests/unit/sources/jquants/test_statements.py
+++ b/tests/unit/sources/jquants/test_statements.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 import polars as pl
 import pytest
 from httpx import Response
-from polars import DataFrame
 
 from kabukit.sources.jquants.client import JQuantsClient
 
@@ -92,7 +91,7 @@ async def test_get_flags(
 
     mock_clean = mocker.patch(
         "kabukit.sources.jquants.statements.clean",
-        return_value=DataFrame(
+        return_value=pl.DataFrame(
             {
                 "Code": ["7203"],
                 "DisclosedDate": [datetime.date(2023, 1, 5)],
@@ -102,7 +101,7 @@ async def test_get_flags(
     )
     mock_with_date = mocker.patch(
         "kabukit.sources.jquants.statements.with_date",
-        return_value=DataFrame({"Date": [datetime.date(2023, 1, 1)]}),
+        return_value=pl.DataFrame({"Date": [datetime.date(2023, 1, 1)]}),
     )
 
     client = JQuantsClient("test_token")
@@ -124,10 +123,10 @@ async def test_get_flags(
 
 
 @pytest.fixture
-def df() -> DataFrame:
+def df() -> pl.DataFrame:
     from kabukit.sources.jquants.statements import clean
 
-    return DataFrame(
+    return pl.DataFrame(
         {
             "DisclosedDate": ["2023-01-01", "2023-01-20", "2023-01-30"],
             "DisclosedTime": ["09:00", "15:30", "12:00"],
@@ -146,29 +145,29 @@ def df() -> DataFrame:
     ).pipe(clean)
 
 
-def test_clean_shape(df: DataFrame) -> None:
+def test_clean_shape(df: pl.DataFrame) -> None:
     assert df.shape == (3, 9)
 
 
-def test_clean_disclosed_date(df: DataFrame) -> None:
+def test_clean_disclosed_date(df: pl.DataFrame) -> None:
     assert df["DisclosedDate"].dtype == pl.Date
 
 
-def test_clean_disclosed_time(df: DataFrame) -> None:
+def test_clean_disclosed_time(df: pl.DataFrame) -> None:
     assert df["DisclosedTime"].dtype == pl.Time
 
 
-def test_clean_current_period(df: DataFrame) -> None:
+def test_clean_current_period(df: pl.DataFrame) -> None:
     assert df["TypeOfCurrentPeriod"].dtype == pl.Categorical
 
 
 @pytest.mark.parametrize("column", ["ForecastProfit", "AverageOutstandingShares"])
-def test_clean_float(df: DataFrame, column: str) -> None:
+def test_clean_float(df: pl.DataFrame, column: str) -> None:
     assert df[column].dtype == pl.Float64
 
 
 @pytest.mark.parametrize("column", ["IssuedShares", "TreasuryShares"])
-def test_clean_int(df: DataFrame, column: str) -> None:
+def test_clean_int(df: pl.DataFrame, column: str) -> None:
     assert df[column].dtype == pl.Int64
 
 
@@ -182,7 +181,7 @@ def test_clean_int(df: DataFrame, column: str) -> None:
         ("RetrospectiveRestatement", [True, False, None]),
     ],
 )
-def test_clean(df: DataFrame, column: str, values: list[Any]) -> None:
+def test_clean(df: pl.DataFrame, column: str, values: list[Any]) -> None:
     assert df[column].to_list() == values
 
 
@@ -191,7 +190,7 @@ def test_with_date() -> None:
 
     from kabukit.sources.jquants.statements import with_date
 
-    df = DataFrame(
+    df = pl.DataFrame(
         {
             "DisclosedDate": [
                 date(2025, 1, 4),

--- a/tests/unit/sources/jquants/test_topix.py
+++ b/tests/unit/sources/jquants/test_topix.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING
 
+import polars as pl
 import pytest
 from httpx import Response
-from polars import DataFrame
 from polars.testing import assert_frame_equal
 
 from kabukit.sources.jquants.client import JQuantsClient
@@ -28,7 +28,7 @@ async def test_get_topix(mock_get: AsyncMock, mocker: MockerFixture) -> None:
     client = JQuantsClient("test_token")
     result = await client.get_topix()
 
-    expected = DataFrame(
+    expected = pl.DataFrame(
         {
             "Date": [datetime.date(2025, 1, 1)],
             "Code": ["TOPIX"],

--- a/tests/unit/utils/test_concurrent.py
+++ b/tests/unit/utils/test_concurrent.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 import pytest
-from polars import DataFrame
 
 from kabukit.sources.base import Client
 
@@ -51,9 +50,9 @@ async def test_collect_fn() -> None:
     assert sorted(result) == [0.01, 0.02, 0.03]
 
 
-async def sleep_df(second: float) -> DataFrame:
+async def sleep_df(second: float) -> pl.DataFrame:
     await asyncio.sleep(second)
-    return DataFrame({"a": [second]})
+    return pl.DataFrame({"a": [second]})
 
 
 @pytest.mark.asyncio
@@ -74,9 +73,9 @@ async def test_concat_fn() -> None:
 
 
 class MockClient(Client):
-    async def get_data(self, code: int) -> DataFrame:
+    async def get_data(self, code: int) -> pl.DataFrame:
         await asyncio.sleep(0.01)
-        return DataFrame({"Code": [code]})
+        return pl.DataFrame({"Code": [code]})
 
 
 @pytest.mark.asyncio
@@ -99,9 +98,9 @@ async def test_get() -> None:
 
 
 async def progress(
-    ait: AsyncIterable[DataFrame],
+    ait: AsyncIterable[pl.DataFrame],
     total: int | None = None,
-) -> AsyncIterator[DataFrame]:
+) -> AsyncIterator[pl.DataFrame]:
     async for x in ait:
         yield x.with_columns(pl.col("Code") * total)
 
@@ -114,7 +113,7 @@ async def test_get_progress() -> None:
     assert df["Code"].sort().to_list() == [3, 6, 9]
 
 
-def callback(df: DataFrame) -> DataFrame:
+def callback(df: pl.DataFrame) -> pl.DataFrame:
     return df.with_columns(pl.col("Code") * 10)
 
 

--- a/tests/validation/prices/test_adjusted_shares.py
+++ b/tests/validation/prices/test_adjusted_shares.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import date
 from typing import TYPE_CHECKING
 
+import polars as pl
 import pytest
 import pytest_asyncio
-from polars import DataFrame
 from polars import col as c
 
 from kabukit.domain.jquants.prices import Prices
@@ -24,7 +24,7 @@ async def prices(statements: Statements) -> Prices:
 
 
 @pytest.fixture(scope="module")
-def data(prices: Prices) -> DataFrame:
+def data(prices: Prices) -> pl.DataFrame:
     data = prices.data
 
     return (
@@ -46,25 +46,25 @@ def data(prices: Prices) -> DataFrame:
     )
 
 
-def test_adjusted_shares_ratio_min(data: DataFrame) -> None:
+def test_adjusted_shares_ratio_min(data: pl.DataFrame) -> None:
     x = data["Ratio"].mean()
     assert isinstance(x, float)
     assert x < 0.05
 
 
-def test_adjusted_shares_ratio_max(data: DataFrame) -> None:
+def test_adjusted_shares_ratio_max(data: pl.DataFrame) -> None:
     x = data["Ratio"].max()
     assert isinstance(x, float)
     assert x < 0.25
 
 
-def test_adjusted_shares_ratio_ratio_min(data: DataFrame) -> None:
+def test_adjusted_shares_ratio_ratio_min(data: pl.DataFrame) -> None:
     x = data["RatioRatio"].min()
     assert isinstance(x, float)
     assert x > 0.995
 
 
-def test_adjusted_shares_ratio_ratio_max(data: DataFrame) -> None:
+def test_adjusted_shares_ratio_ratio_max(data: pl.DataFrame) -> None:
     x = data["RatioRatio"].max()
     assert isinstance(x, float)
     assert x < 1.05

--- a/tests/validation/prices/test_period_stats.py
+++ b/tests/validation/prices/test_period_stats.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import date
 from typing import TYPE_CHECKING
 
+import polars as pl
 import pytest
 import pytest_asyncio
-from polars import DataFrame
 from polars import col as c
 
 from kabukit.domain.jquants.prices import Prices
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 @pytest_asyncio.fixture(scope="module")
-async def data(statements: Statements) -> DataFrame:
+async def data(statements: Statements) -> pl.DataFrame:
     codes = ["7203"]  # トヨタのみ
     data = await get("prices", codes)
     return Prices(data).with_yields(statements).period_stats()
@@ -30,7 +30,7 @@ async def data(statements: Statements) -> DataFrame:
     ],
 )
 def test_book_value_yield_period_open_7203(
-    data: DataFrame,
+    data: pl.DataFrame,
     d: date,
     expected: float,
 ) -> None:

--- a/tests/validation/statements/conftest.py
+++ b/tests/validation/statements/conftest.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import polars as pl
 import pytest
-from polars import DataFrame
 from polars import col as c
 
 if TYPE_CHECKING:
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture(scope="module")
-def data(statements: Statements) -> DataFrame:
+def data(statements: Statements) -> pl.DataFrame:
     return statements.data
 
 
@@ -69,13 +69,13 @@ def cf_col(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture(scope="module")
-def fin(data: DataFrame) -> DataFrame:
+def fin(data: pl.DataFrame) -> pl.DataFrame:
     """決算の行だけ抽出する"""
     return data.filter(c.TypeOfDocument.str.contains("Financial"))
 
 
 @pytest.fixture(scope="module")
-def earn_revision(data: DataFrame) -> DataFrame:
+def earn_revision(data: pl.DataFrame) -> pl.DataFrame:
     """業績修正の行だけ抽出し、共通カラムと全て欠損のカラムを削除"""
     df = data.filter(c.TypeOfDocument == "EarnForecastRevision")
     cols = [c for c in df.columns if df[c].is_null().all() or c in COMMON_COLUMNS]
@@ -83,7 +83,7 @@ def earn_revision(data: DataFrame) -> DataFrame:
 
 
 @pytest.fixture(scope="module")
-def dividend_revision(data: DataFrame) -> DataFrame:
+def dividend_revision(data: pl.DataFrame) -> pl.DataFrame:
     """配当修正の行だけ抽出し、共通カラムと全て欠損のカラムを削除"""
     df = data.filter(c.TypeOfDocument == "DividendForecastRevision")
     cols = [c for c in df.columns if df[c].is_null().all() or c in COMMON_COLUMNS]

--- a/tests/validation/statements/test_validity.py
+++ b/tests/validation/statements/test_validity.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import date
 from typing import TYPE_CHECKING
 
+import polars as pl
 import pytest
-from polars import DataFrame
 from polars import col as c
 
 from tests.validation.conftest import pytestmark  # noqa: F401
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 # 指標が乖離している決算書を確認する必要あり
 
 
-def test_equity_to_asset_ratio(data: DataFrame) -> None:
+def test_equity_to_asset_ratio(data: pl.DataFrame) -> None:
     x = data["EquityToAssetRatio"]
     y = data["Equity"] / data["TotalAssets"]
     r = x / y
@@ -24,7 +24,7 @@ def test_equity_to_asset_ratio(data: DataFrame) -> None:
     assert m > 0.93
 
 
-def test_earnings_per_share(data: DataFrame) -> None:
+def test_earnings_per_share(data: pl.DataFrame) -> None:
     """EPS = 当期純利益 / 期中平均株式数"""
     x = data["EarningsPerShare"]
     y = data["Profit"] / data["AverageOutstandingShares"]
@@ -36,7 +36,11 @@ def test_earnings_per_share(data: DataFrame) -> None:
 
 @pytest.mark.parametrize("prefix", ["", "NextYear"])
 @pytest.mark.parametrize("suffix", ["", "2ndQuarter"])
-def test_forecast_earnings_per_share(data: DataFrame, prefix: str, suffix: str) -> None:
+def test_forecast_earnings_per_share(
+    data: pl.DataFrame,
+    prefix: str,
+    suffix: str,
+) -> None:
     """EPS_予想 = 純利益_予想 / 期中平均株式数"""
     x = data[f"{prefix}ForecastEarningsPerShare{suffix}"]
     y = data[f"{prefix}ForecastProfit{suffix}"] / data["AverageOutstandingShares"]
@@ -46,7 +50,7 @@ def test_forecast_earnings_per_share(data: DataFrame, prefix: str, suffix: str) 
     assert m > 0.94
 
 
-def test_bookvalue_per_share(data: DataFrame) -> None:
+def test_bookvalue_per_share(data: pl.DataFrame) -> None:
     """BPS = 純資産 / 期中平均株式数"""
     x = data["BookValuePerShare"]
     y = data["Equity"] / data["AverageOutstandingShares"]
@@ -56,7 +60,7 @@ def test_bookvalue_per_share(data: DataFrame) -> None:
     assert m > 0.9
 
 
-def test_dividend_per_share(data: DataFrame) -> None:
+def test_dividend_per_share(data: pl.DataFrame) -> None:
     """DPS = 配当金 / 期中平均株式数"""
     x = data["ResultDividendPerShareAnnual"]
     y = data["ResultTotalDividendPaidAnnual"] / data["AverageOutstandingShares"]
@@ -67,7 +71,7 @@ def test_dividend_per_share(data: DataFrame) -> None:
 
 
 @pytest.mark.parametrize("prefix", ["Result", "Forecast", "NextYearForecast"])
-def test_dividend_per_share_sum(data: DataFrame, prefix: str) -> None:
+def test_dividend_per_share_sum(data: pl.DataFrame, prefix: str) -> None:
     x = data[f"{prefix}DividendPerShareAnnual"]
     y = (
         data[f"{prefix}DividendPerShare1stQuarter"]
@@ -88,7 +92,7 @@ def test_dividend_per_share_sum(data: DataFrame, prefix: str) -> None:
         ("ResultTotalDividendPaidAnnual", "Profit"),
     ],
 )
-def test_payout_ratio(data: DataFrame, d: str, e: str) -> None:
+def test_payout_ratio(data: pl.DataFrame, d: str, e: str) -> None:
     """配当性向 = 配当金 / 当期利益 = DPS / EPS"""
     x = data["ResultPayoutRatioAnnual"]
     y = data[d] / data[e]
@@ -98,7 +102,7 @@ def test_payout_ratio(data: DataFrame, d: str, e: str) -> None:
     assert m > 0.97
 
 
-def test_earnings_per_share_consistency(data: DataFrame) -> None:
+def test_earnings_per_share_consistency(data: pl.DataFrame) -> None:
     """
     サマリーの利益額(Profit)は丸められている。
     決算短信の詳細数値を使うと、EPSを再現できることを示す。


### PR DESCRIPTION
Use `import polars as pl` across the project instead of `from polars import ...`.

This aligns the codebase with the common community convention for polars, improving readability and preventing potential namespace conflicts.