### PR TITLE
refactor: `edinet.concurrent` モジュールの `get` 関数を削除する

### DIFF
--- a/src/kabukit/sources/edinet/concurrent.py
+++ b/src/kabukit/sources/edinet/concurrent.py
@@ -16,46 +16,6 @@ if TYPE_CHECKING:
     from kabukit.utils.concurrent import Callback, Progress
 
 
-async def get(
-    resource: str,
-    args: Iterable[str | datetime.date],
-    /,
-    max_items: int | None = None,
-    max_concurrency: int | None = None,
-    progress: Progress | None = None,
-    callback: Callback | None = None,
-) -> pl.DataFrame:
-    """引数に対応する各種データを取得し、単一のDataFrameにまとめて返す。
-
-    Args:
-        resource (str): 取得するデータの種類。EdinetClientのメソッド名から"get_"を
-            除いたものを指定する。
-        args (Iterable[str | datetime.date]): 取得対象の引数のリスト。
-        max_items (int | None, optional): 取得数の上限。
-            指定しないときはすべてを取得する。
-        max_concurrency (int | None, optional): 同時に実行するリクエストの最大数。
-            指定しないときはデフォルト値が使用される。
-        progress (Progress | None, optional): 進捗表示のための関数。
-            tqdm, marimoなどのライブラリを使用できる。
-            指定しないときは進捗表示は行われない。
-        callback (Callback | None, optional): 各DataFrameに対して適用する
-            コールバック関数。指定しないときはそのままのDataFrameが使用される。
-
-    Returns:
-        DataFrame:
-            すべての書類情報を含む単一のDataFrame。
-    """
-    return await concurrent.get(
-        EdinetClient,
-        resource,
-        args,
-        max_items=max_items,
-        max_concurrency=max_concurrency,
-        progress=progress,
-        callback=callback,
-    )
-
-
 async def get_list(
     dates: Iterable[datetime.date | str] | datetime.date | str | None = None,
     /,
@@ -95,7 +55,8 @@ async def get_list(
     if dates is None:
         dates = get_dates(days=days, years=years)
 
-    df = await get(
+    df = await concurrent.get(
+        EdinetClient,
         "list",
         dates,
         max_items=max_items,
@@ -142,7 +103,8 @@ async def get_documents(
         async with EdinetClient() as client:
             return await client.get_document(doc_ids, pdf=pdf)
 
-    df = await get(
+    df = await concurrent.get(
+        EdinetClient,
         "pdf" if pdf else "csv",
         doc_ids,
         max_items=max_items,

--- a/tests/system/sources/edinet/test_concurrent.py
+++ b/tests/system/sources/edinet/test_concurrent.py
@@ -8,23 +8,13 @@ import pytest
 pytestmark = pytest.mark.system
 
 
-@pytest.mark.asyncio
-async def test_get() -> None:
-    from kabukit.sources.edinet.concurrent import get
-
-    df = await get("list", ["2025-09-09", "2025-09-19", "2025-09-22"])
-    assert df.shape == (1231, 30)
-    assert df["Date"].n_unique() == 3
-    assert df["docID"].n_unique() == 1229  # 重複あり
-
-
 def callback(df: pl.DataFrame) -> pl.DataFrame:
     assert isinstance(df, pl.DataFrame)
     return df
 
 
 @pytest.mark.asyncio
-async def mock_get_list_single_date() -> None:
+async def test_get_list_single_date() -> None:
     from kabukit.sources.edinet.concurrent import get_list
 
     df = await get_list("2025-10-09")
@@ -34,7 +24,7 @@ async def mock_get_list_single_date() -> None:
 
 
 @pytest.mark.asyncio
-async def mock_get_list_multiple_dates() -> None:
+async def test_get_list_multiple_dates() -> None:
     from kabukit.sources.edinet.concurrent import get_list
 
     df = await get_list(["2025-10-09", "2025-10-10"])
@@ -43,7 +33,7 @@ async def mock_get_list_multiple_dates() -> None:
 
 
 @pytest.mark.asyncio
-async def mock_get_list_without_dates() -> None:
+async def test_get_list_without_dates() -> None:
     from kabukit.sources.edinet.concurrent import get_list
 
     df = await get_list(days=7, max_items=6, callback=callback)


### PR DESCRIPTION
## 概要

### 背景

`src/kabukit/sources/edinet/concurrent.py` に定義されている `get` 関数は、汎用的な `kabukit.utils.concurrent.get` を `EdinetClient` 専用にラップしたヘルパー関数です。

この関数は、同じモジュール内の `get_entries` と `get_documents` からのみ使用されており、外部からの参照がありません。

### 提案

この `get` ヘルパー関数を削除し、`get_entries` と `get_documents` から `kabukit.utils.concurrent.get` を直接呼び出すようにリファクタリングします。

これにより、不要な抽象化レイヤーが1つ削除され、コードがより直接的でシンプルになります。

## タスクリスト

- [x] `src/kabukit/sources/edinet/concurrent.py` の `get_entries` 関数内で、`get` の呼び出しを `kabukit.utils.concurrent.get` の直接呼び出しに置き換える。
- [x] `src/kabukit/sources/edinet/concurrent.py` の `get_documents` 関数内で、`get` の呼び出しを `kabukit.utils.concurrent.get` の直接呼び出しに置き換える。
- [x] `src/kabukit/sources/edinet/concurrent.py` から不要になった `get` 関数を削除する。